### PR TITLE
fix: refresh screen frame list on Compass state changes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,11 @@
       "Bash(docker run *)",
       "Bash(grep -nB2 -A12 'struct InputEvent' vendor/meshtastic-firmware/src/input/InputBroker.h)",
       "Bash(grep -nB2 -A12 'class InputEvent\\\\|^struct InputEvent\\\\|InputEvent {' vendor/meshtastic-firmware/src/input/InputBroker.h)",
-      "Bash(grep -nB2 -A4 'class InputBroker' vendor/meshtastic-firmware/src/input/InputBroker.h)"
+      "Bash(grep -nB2 -A4 'class InputBroker' vendor/meshtastic-firmware/src/input/InputBroker.h)",
+      "Bash(grep -nA3 'INPUT_BROKER_SELECT_LONG.*\\\\|INPUT_BROKER_BACK\\\\|TRACKING_TREASURE\\\\|SESSION_PAUSED' firmware-overlay/src/modules/CompassModule/CompassUI.cpp)",
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(git push *)"
     ],
     "deny": [],
     "additionalDirectories": [

--- a/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
@@ -31,6 +31,14 @@ CompassModule::CompassModule()
     if (inputBroker) _inputObserver.observe(inputBroker);
 }
 
+// --- UI refresh helper -------------------------------------------------
+
+void CompassModule::notifyUIChanged() {
+    UIFrameEvent e;
+    e.action = UIFrameEvent::Action::REGENERATE_FRAMESET;
+    notifyObservers(&e);
+}
+
 // --- UI overrides (delegate to CompassUI) -----------------------------
 
 bool CompassModule::wantUIFrame() {
@@ -104,6 +112,7 @@ void CompassModule::sendPacket(uint32_t to, uint8_t hopLimit, const meshtastic_C
 
 void CompassModule::sendCapabilityQuery() {
     _state.startDiscovery();
+    notifyUIChanged();
     meshtastic_CompassPacket pkt = meshtastic_CompassPacket_init_default;
     pkt.type = meshtastic_CompassMsgType_CAPABILITY_QUERY;
     sendPacket(NODENUM_BROADCAST, /*hop_limit=*/0, pkt);
@@ -118,6 +127,7 @@ void CompassModule::sendCapabilityAdv(uint32_t toNodeNum) {
 
 void CompassModule::sendPairRequest(uint32_t targetNodeNum) {
     _state.startPairRequest(targetNodeNum);
+    notifyUIChanged();
     meshtastic_CompassPacket pkt = meshtastic_CompassPacket_init_default;
     pkt.type = meshtastic_CompassMsgType_PAIR_REQUEST;
     sendPacket(targetNodeNum, /*hop_limit=*/0, pkt);
@@ -149,6 +159,7 @@ void CompassModule::sendSessionEnd() {
     pkt.type = meshtastic_CompassMsgType_SESSION_END;
     sendPacket(peer, /*hop_limit=*/3, pkt);
     _state.endSession();
+    notifyUIChanged();
 }
 
 // --- Per-message handlers ---------------------------------------------
@@ -168,6 +179,7 @@ void CompassModule::handleCapabilityAdv(const meshtastic_MeshPacket &mp,
 
 void CompassModule::handlePairRequest(const meshtastic_MeshPacket &mp) {
     _state.onPairRequestReceived(mp.from);
+    notifyUIChanged();
 }
 
 void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
@@ -175,6 +187,7 @@ void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
     const char *peerName = (info && info->has_user) ? info->user.long_name : "";
     _state.onPairAccepted(mp.from, peerName);
     sendPairConfirm(mp.from);
+    notifyUIChanged();
 }
 
 void CompassModule::handlePairConfirm(const meshtastic_MeshPacket &mp) {
@@ -184,6 +197,7 @@ void CompassModule::handlePairConfirm(const meshtastic_MeshPacket &mp) {
 
 void CompassModule::handlePairReject(const meshtastic_MeshPacket & /*mp*/) {
     _state.onPairRejected();
+    notifyUIChanged();
 }
 
 void CompassModule::handlePositionUpdate(const meshtastic_MeshPacket &mp,
@@ -196,18 +210,30 @@ void CompassModule::handlePositionUpdate(const meshtastic_MeshPacket &mp,
 void CompassModule::handleSessionEnd(const meshtastic_MeshPacket &mp) {
     if (mp.from != _state.session().peerNodeNum) return;
     _state.onSessionEnd();
+    notifyUIChanged();
 }
 
 // --- Scheduler ---------------------------------------------------------
 
 int32_t CompassModule::runOnce() {
     using compass::State;
-    if (_state.getState() == State::CALIBRATING && _mag.isReady()) {
+
+    // Backstop: catch any state transition that happened since the last
+    // tick (auto SESSION_PAUSED in particular, which has no explicit call
+    // site). Inline notifyUIChanged() calls in send/handle helpers cover
+    // user-action latency; this loop catches whatever they miss.
+    State current = _state.getState();
+    if (current != _prevState) {
+        notifyUIChanged();
+        _prevState = current;
+    }
+
+    if (current == State::CALIBRATING && _mag.isReady()) {
         int16_t mx = 0, my = 0, mz = 0;
         if (_mag.read(mx, my, mz)) _state.feedCalSample(mx, my, mz);
     }
 
-    switch (_state.getState()) {
+    switch (current) {
         case State::IDLE:
         case State::DISCOVERING:
         case State::AWAITING_PAIR_ACCEPT:
@@ -224,6 +250,8 @@ int32_t CompassModule::runOnce() {
     }
     return 1000;
 }
+
+
 
 int32_t CompassModule::tickTracked() {
     if (_state.session().peerNodeNum == 0) {

--- a/firmware-overlay/src/modules/CompassModule/CompassModule.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.h
@@ -46,6 +46,14 @@ public:
     compass::CompassState *state() { return &_state; }
     Magnetometer          *mag()   { return &_mag; }
 
+    // Tell the Screen subsystem to re-poll wantUIFrame() on every module
+    // and rebuild its frame list. Must be called whenever we transition into
+    // or out of a state where wantUIFrame() flips. Without this call, the
+    // screen continues to show the previous frame rotation regardless of
+    // our internal state. (See WaypointModule / CannedMessageModule for
+    // upstream's usage pattern.)
+    void notifyUIChanged();
+
     static CompassModule *instance;
 
 protected:
@@ -53,6 +61,7 @@ protected:
 
 private:
     compass::CompassState _state;
+    compass::State        _prevState = compass::State::IDLE;  // tick-based UI-refresh backstop
     Magnetometer          _mag;
     CompassUI             _ui{this};
     CallbackObserver<CompassModule, const InputEvent *> _inputObserver{

--- a/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
@@ -241,7 +241,10 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
         case State::DISCOVERING: {
             const uint8_t count = st->discoveredNodeCount();
             if (count == 0) {
-                if (e->inputEvent == INPUT_BROKER_SELECT_LONG) st->endSession();
+                if (e->inputEvent == INPUT_BROKER_SELECT_LONG) {
+                    st->endSession();
+                    _owner->notifyUIChanged();
+                }
                 return 0;
             }
             if (e->inputEvent == INPUT_BROKER_UP) {
@@ -253,6 +256,7 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
             } else if (e->inputEvent == INPUT_BROKER_SELECT_LONG ||
                        e->inputEvent == INPUT_BROKER_BACK) {
                 st->endSession();
+                _owner->notifyUIChanged();
             }
             return 1;
         }
@@ -271,15 +275,18 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
                     st->rejectPair();
                     _owner->sendPairReject(initiator);
                 }
+                _owner->notifyUIChanged();
             }
             return 1;
         }
         case State::CALIBRATING: {
             if (e->inputEvent == INPUT_BROKER_SELECT) {
                 st->finishCalibration();
+                _owner->notifyUIChanged();
             } else if (e->inputEvent == INPUT_BROKER_SELECT_LONG ||
                        e->inputEvent == INPUT_BROKER_BACK) {
                 st->endSession();
+                _owner->notifyUIChanged();
             }
             return 1;
         }
@@ -288,8 +295,11 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
         case State::SESSION_PAUSED: {
             if (e->inputEvent == INPUT_BROKER_SELECT_LONG ||
                 e->inputEvent == INPUT_BROKER_BACK) {
-                // Release UI frame; tracking continues in background.
-                // (Screen->setFrames() is called by CompassModule's observer notify.)
+                // End session and refresh frame list so screen rotation
+                // returns to its normal behavior. The "minimize but keep
+                // tracking" UX is a v2 follow-up (bead -dyg).
+                st->endSession();
+                _owner->notifyUIChanged();
                 return 1;
             }
             return 0;


### PR DESCRIPTION
## Summary

Reported by tester: clicking **Compass** in the home banner menu closed the menu but never showed the discovery screen — the device just resumed its normal frame rotation (stock Meshtastic frames).

**Root cause:** `CompassModule` never called `notifyObservers(&UIFrameEvent{REGENERATE_FRAMESET})`. Without that notification, the Screen subsystem keeps its existing frame list and never re-polls each module's `wantUIFrame()`. The internal state machine **was** transitioning correctly (`sendCapabilityQuery` flipped the FSM to DISCOVERING and broadcast the packet) — Screen just didn't know to ask us about it.

`WaypointModule` and `CannedMessageModule` both notify on every UI-affecting transition. We didn't. Now we do.

## Fix

Belt-and-suspenders so we don't miss a transition again:

1. **`CompassModule::notifyUIChanged()`** helper emits `REGENERATE_FRAMESET`.
2. **Inline calls** in send/handle helpers (`sendCapabilityQuery`, `sendPairRequest`, `sendSessionEnd`, `handlePair{Request,Accept,Reject}`, `handleSessionEnd`) — covers user-action sites with no perceptible latency.
3. **CompassUI** input handlers call `_owner->notifyUIChanged()` after any `_state` mutation that affects `wantUIFrame()` (accept/reject pair, end session, finish calibration).
4. **`runOnce()` backstop:** tracks `_prevState`; notifies on any change the inline calls miss — covers auto `SESSION_PAUSED` and any future transition site we forget to instrument. ~500ms worst-case latency, imperceptible in practice.

Also tightens TRACKING/SESSION_PAUSED long-press handling: previously it returned "intercepted" without doing anything, leaving the user stuck in TRACKING until the 5min auto-pause. Now it ends the session and refreshes frames. The "minimize-but-keep-tracking" UX remains a v2 follow-up (tracked in bead `-dyg`).

## Why no test coverage

Per follow-up discussion: there isn't a Playwright-equivalent for Meshtastic firmware UI navigation. Closest options are Portduino native + custom Python harness (soniccyclone's `tests/smoke/` pattern) or upstream's `meshTestic` (drives **physical** USB-connected devices). A "headless UI navigation" rig would need a custom Portduino display backend that exposes the OLEDDisplay framebuffer for readback — ~a week of plumbing, deferred to v2.

For this bug, the diagnosis was direct from code reading and the fix is small + cross-checked against two upstream modules with the same pattern.

## Test plan

- [x] Cross-arch build succeeds (compiles cleanly against v2.7.15.567b8ea)
- [ ] **Manual on hardware:** clicking "Compass" in the home banner menu now transitions to the discovery list within ~500ms
- [ ] **Manual on hardware:** with two T114s, full pairing flow (CUJ-3) shows correct UI transitions on both sides
- [ ] **Manual on hardware:** long-press SELECT in TRACKING ends the session and returns to normal screen rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)