### PR TITLE
feat(bd-9-1): Compass submenu skeleton

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,33 @@
 {
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  },
   "permissions": {
+    "additionalDirectories": [
+      "/home/nathan/code-stuff/meshtastic-captains-compass",
+      "/home/nathan/code-stuff/meshtastic-firmware/protobufs/meshtastic"
+    ],
     "allow": [
       "Read(*)",
       "Write(*)",
@@ -31,34 +59,6 @@
       "Bash(git commit -m ' *)",
       "Bash(git push *)"
     ],
-    "deny": [],
-    "additionalDirectories": [
-      "/home/nathan/code-stuff/meshtastic-captains-compass",
-      "/home/nathan/code-stuff/meshtastic-firmware/protobufs/meshtastic"
-    ]
-  },
-  "hooks": {
-    "PreCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bd prime"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bd prime"
-          }
-        ]
-      }
-    ]
+    "deny": []
   }
 }

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -1,0 +1,104 @@
+// Captain's Compass — submenu implementation.
+// See docs/tdd-issue-009-compass-submenu.md §3.
+
+#include "CompassMenu.h"
+
+#include "CompassModule.h"
+#include "configuration.h"
+#include "graphics/Screen.h"
+#include "graphics/draw/MenuHandler.h"
+
+using compass::CompassMenu;
+using graphics::BannerOverlayOptions;
+
+const char *CompassMenu::pendingToast = nullptr;
+
+void CompassMenu::open() {
+    graphics::menuHandler::menuQueue = graphics::menuHandler::compass_menu;
+}
+
+void CompassMenu::buildRoot() {
+    // Order and labels are the source of truth for PRD §5. If you change
+    // either here, also update prd-issue-009-compass-submenu.md §5.
+    enum opt {
+        Back,
+        FindDesire,
+        Treasures,
+        SaveTreasure,
+        Calibrate,
+        EndSession,
+        Status,
+        Settings,
+        enumEnd,
+    };
+
+    static const char *labels[enumEnd] = {
+        "Back", "Find Desire", "Treasures", "Save Treasure",
+        "Calibrate", "End Session", "Status", "Settings",
+    };
+    static int enums[enumEnd] = {
+        Back, FindDesire, Treasures, SaveTreasure,
+        Calibrate, EndSession, Status, Settings,
+    };
+
+    BannerOverlayOptions opts;
+    opts.message = "Compass";
+    opts.optionsArrayPtr = labels;
+    opts.optionsEnumPtr = enums;
+    opts.optionsCount = enumEnd;
+    opts.bannerCallback = [](int selected) -> void {
+        switch (selected) {
+            case FindDesire:
+                LOG_INFO("Compass menu: Find Desire (stub — bd-9-2)");
+                break;
+            case Treasures:
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
+                break;
+            case SaveTreasure:
+                LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
+                break;
+            case Calibrate:
+                LOG_INFO("Compass menu: Calibrate (stub — bd-9-2)");
+                break;
+            case EndSession:
+                LOG_INFO("Compass menu: End Session (stub — bd-9-2)");
+                break;
+            case Status:
+                LOG_INFO("Compass menu: Status (stub — bd-9-5)");
+                break;
+            case Settings:
+                CompassMenu::pendingToast = "Coming soon";
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
+                break;
+            case Back:
+            default:
+                break;
+        }
+    };
+    if (screen) screen->showOverlayBanner(opts);
+}
+
+void CompassMenu::buildTreasures() {
+    // bd-9-4 replaces this stub with a list dynamically built from
+    // CompassModule::instance->state()->treasureCount(). For the
+    // skeleton we just show a placeholder so QA can verify the dispatch
+    // path lands here.
+    static const char *labels[] = {"Back", "(populated in bd-9-4)"};
+    static int enums[] = {0, 1};
+
+    BannerOverlayOptions opts;
+    opts.message = "Treasures";
+    opts.optionsArrayPtr = labels;
+    opts.optionsEnumPtr = enums;
+    opts.optionsCount = 2;
+    opts.bannerCallback = [](int /*selected*/) -> void {
+        LOG_INFO("Compass menu: Treasures pick (stub — bd-9-4)");
+    };
+    if (screen) screen->showOverlayBanner(opts);
+}
+
+void CompassMenu::showPendingToast() {
+    const char *msg = CompassMenu::pendingToast ? CompassMenu::pendingToast : "";
+    CompassMenu::pendingToast = nullptr;
+    if (screen) screen->showSimpleBanner(msg, 2000);
+}

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.h
@@ -1,0 +1,42 @@
+// Captain's Compass — submenu (the screen pushed by the home banner-menu's
+// `Compass` entry). See docs/tdd-issue-009-compass-submenu.md §3.
+//
+// The class is a function bag: all members are static. Lifetime is "forever";
+// no instance, no allocation. Two reasons:
+//   1. The banner-menu API (BannerOverlayOptions::bannerCallback) is a
+//      std::function captured at showOverlayBanner() time, so callbacks must
+//      either be capture-less lambdas or reference globals. Statics fit.
+//   2. There is exactly one Compass submenu surface; modeling it as a class
+//      with state would just be ceremony.
+//
+// Re-entrance: never call `screen->showOverlayBanner(...)` from inside another
+// banner's callback — upstream's NotificationRenderer assumes the previous
+// banner is closing when a callback fires. To open another submenu, set
+// `graphics::menuHandler::menuQueue` and let the next frame's
+// `handleMenuSwitch` dispatch the build function. This is the same pattern
+// `systemBaseMenu`, `loraMenu`, etc. use upstream.
+
+#pragma once
+
+#include "configuration.h"
+
+namespace compass {
+
+class CompassMenu {
+public:
+    // Called from the home banner-menu's `Compass` callback. Queues the
+    // root submenu for the next frame.
+    static void open();
+
+    // Dispatch entry points called from `menuHandler::handleMenuSwitch`
+    // patched cases. See patches/apply.py::patch_screen_cpp.
+    static void buildRoot();
+    static void buildTreasures();
+    static void showPendingToast();
+
+    // Set by callbacks before queueing `compass_toast`. Lives across one
+    // frame (set in callback, read in dispatch case, never both).
+    static const char *pendingToast;
+};
+
+} // namespace compass

--- a/patches/apply.py
+++ b/patches/apply.py
@@ -159,16 +159,56 @@ def patch_modules_cpp(dry_run=False):
     print(f"  Patched {path}")
 
 
-def patch_screen_cpp(dry_run=False):
-    """Add 'Compass' entry to the home banner menu in MenuHandler.cpp.
+def patch_menuhandler_h(dry_run=False):
+    """Extend graphics::menuHandler::screenMenus with three Compass values.
 
-    Three coordinated substitutions in src/graphics/draw/MenuHandler.cpp:
+    Why: upstream's banner-menu re-entrance contract forbids calling
+    `screen->showOverlayBanner(...)` from inside another banner's callback
+    (NotificationRenderer assumes the previous banner is closing). Every
+    upstream nested-menu transition uses `menuQueue = X` and lets the next
+    frame's `handleMenuSwitch` dispatch. We follow the same pattern; that
+    requires three queue values:
+
+      * compass_menu             — open the Compass root submenu
+      * compass_treasure_picker  — open the nested treasure-list submenu
+      * compass_toast            — show a deferred toast
+                                   (CompassMenu::pendingToast holds the text)
+
+    Anchor: the last entry of the enum (`DisplayUnits` followed by a
+    closing brace). Stable: the enum is only appended-to upstream and
+    `DisplayUnits` is the current tail at v2.7.15.567b8ea.
+    """
+    _apply(
+        "src/graphics/draw/MenuHandler.h",
+        anchor="        DisplayUnits\n    };",
+        replacement=(
+            "        DisplayUnits,\n"
+            f"        /* {MARKER} */\n"
+            "        compass_menu,\n"
+            "        compass_treasure_picker,\n"
+            "        compass_toast\n"
+            "    };"
+        ),
+        dry_run=dry_run,
+        position="replace",
+    )
+
+
+def patch_screen_cpp(dry_run=False):
+    """Wire the home banner-menu's `Compass` entry to push the Compass submenu.
+
+    Six coordinated substitutions in src/graphics/draw/MenuHandler.cpp:
       1. enum optionsNumbers — add Compass before enumEnd
       2. options array — append Compass entry after the Position branch
       3. bannerCallback lambda — add 'else if (selected == Compass)' case
-    Plus an #include for CompassModule.h.
+         that QUEUES the Compass root submenu (does NOT directly call any
+         CompassModule send method — that was Bug 1 in issue #9).
+      4. handleMenuSwitch — three new cases dispatching the queued values
+         to CompassMenu::buildRoot / buildTreasures / showPendingToast.
+      5. #include "modules/CompassModule/CompassModule.h"
+      6. #include "modules/CompassModule/CompassMenu.h"
 
-    All four are idempotency-checked via the MARKER scan at function entry;
+    All six are idempotency-checked via the MARKER scan at function entry;
     once patched, every subsequent call is a no-op.
     """
     path = "src/graphics/draw/MenuHandler.cpp"
@@ -181,9 +221,12 @@ def patch_screen_cpp(dry_run=False):
     cb_anchor     = ("        } else if (selected == Freetext) {\n"
                      "            cannedMessageModule->LaunchFreetextWithDestination(NODENUM_BROADCAST);\n"
                      "        }")
+    switch_anchor = ("    case throttle_message:\n"
+                     "        screen->showSimpleBanner(\"Too Many Attempts\\nTry again in 60 seconds.\", 5000);\n"
+                     "        break;")
     include_anchor = '#include "MenuHandler.h"'
 
-    for a in (enum_anchor, array_anchor, cb_anchor, include_anchor):
+    for a in (enum_anchor, array_anchor, cb_anchor, switch_anchor, include_anchor):
         if a not in text:
             sys.exit(f"ERROR: anchor missing in {path}: {a!r}")
     if dry_run:
@@ -195,9 +238,6 @@ def patch_screen_cpp(dry_run=False):
         f"Sleep, Compass, enumEnd  /* {MARKER} */",
     )
     text = text.replace(enum_anchor, enum_replacement, 1)
-    # The Position case in v2.7.15 dispatches via injectInputEvent rather than
-    # service->trySendPosition. We don't depend on that detail; we just add a
-    # new Compass case to the lambda after the Freetext case.
 
     # 2. options array: append after Position branch
     array_replacement = (
@@ -208,21 +248,41 @@ def patch_screen_cpp(dry_run=False):
     )
     text = text.replace(array_anchor, array_replacement, 1)
 
-    # 3. bannerCallback lambda: add Compass case after Freetext
+    # 3. bannerCallback lambda: add Compass case after Freetext.
+    # Sets menuQueue and returns; the next frame's handleMenuSwitch builds
+    # the submenu via CompassMenu::buildRoot(). Direct-call to
+    # showOverlayBanner from a callback would race the NotificationRenderer
+    # cleanup of the home banner — see TDD §3.5.
     cb_replacement = (
         cb_anchor + " "
         f"/* {MARKER} */ else if (selected == Compass) {{\n"
-        "            if (CompassModule::instance) {\n"
-        "                CompassModule::instance->sendCapabilityQuery();\n"
-        "            }\n"
+        "            menuQueue = compass_menu;\n"
         "        }"
     )
     text = text.replace(cb_anchor, cb_replacement, 1)
 
-    # 4. include
+    # 4. handleMenuSwitch cases: dispatch the three queue values.
+    switch_replacement = (
+        switch_anchor + "\n"
+        f"    /* {MARKER} */\n"
+        "    case compass_menu:\n"
+        "        compass::CompassMenu::buildRoot();\n"
+        "        break;\n"
+        "    case compass_treasure_picker:\n"
+        "        compass::CompassMenu::buildTreasures();\n"
+        "        break;\n"
+        "    case compass_toast:\n"
+        "        compass::CompassMenu::showPendingToast();\n"
+        "        break;"
+    )
+    text = text.replace(switch_anchor, switch_replacement, 1)
+
+    # 5/6. includes (CompassModule.h for instance ptr, CompassMenu.h for the
+    # static dispatch entry points).
     include_replacement = (
         include_anchor + f'\n// {MARKER}\n'
-        '#include "modules/CompassModule/CompassModule.h"'
+        '#include "modules/CompassModule/CompassModule.h"\n'
+        '#include "modules/CompassModule/CompassMenu.h"'
     )
     text = text.replace(include_anchor, include_replacement, 1)
 
@@ -239,6 +299,7 @@ PATCHES = [
     patch_variant_cpp,
     patch_portnums_proto,
     patch_modules_cpp,
+    patch_menuhandler_h,
     patch_screen_cpp,
 ]
 


### PR DESCRIPTION
## Summary
- New \`firmware-overlay/src/modules/CompassModule/CompassMenu.{h,cpp}\` — function-bag class owning the submenu inventory (PRD §5).
- \`patches/apply.py\` extended: new \`patch_menuhandler_h\` adds three values (\`compass_menu\`, \`compass_treasure_picker\`, \`compass_toast\`) to \`graphics::menuHandler::screenMenus\`; existing \`patch_screen_cpp\` now also patches \`handleMenuSwitch\` with the three dispatch cases and rewrites the home menu's \`Compass\` callback from \`sendCapabilityQuery()\` to \`menuQueue = compass_menu;\`.
- All apply.py anchors verified against the pinned firmware ref \`v2.7.15.567b8ea\` via \`--dry-run\`.

## Why this shape (not direct \`showOverlayBanner\` from the home callback)

Upstream's \`NotificationRenderer\` assumes the previous banner is closing when its callback fires. Calling \`screen->showOverlayBanner(...)\` recursively from inside a callback would race the cleanup of the previous banner. Every upstream nested-menu transition (\`loraMenu\`, \`systemBaseMenu\`, etc.) sets \`menuQueue = X\` and lets the next frame's \`handleMenuSwitch\` build the new menu — we follow the same pattern, which is why the patch surface is three new enum values + three new dispatch cases.

## Per-entry status

| Entry         | This PR                                  | Followup |
|---------------|------------------------------------------|----------|
| Find Desire   | LOG_INFO stub                            | bd-9-2 |
| Treasures     | Queues nested submenu (placeholder body) | bd-9-4 |
| Save Treasure | LOG_INFO stub                            | bd-9-3 |
| Calibrate     | LOG_INFO stub                            | bd-9-2 |
| End Session   | LOG_INFO stub                            | bd-9-2 |
| Status        | LOG_INFO stub                            | bd-9-5 |
| Settings      | "Coming soon" toast (real, via queue)    | — |
| Back          | Implicit (banner-menu primitive)         | — |

Refs #9. Closes bd-9-1 (\`meshtastic-captains-compass-anr\`).

## Test plan
- [x] \`apply.py --dry-run\` against fetched \`v2.7.15.567b8ea\` — all anchors present.
- [x] \`apply.py\` (full apply) on a fresh fetch — all six substitutions in MenuHandler.cpp + the enum extension in MenuHandler.h land cleanly.
- [ ] \`make build\` succeeds (running in background — will report status as a follow-up).
- [ ] On hardware (deferred — flagged in bd-9-1 acceptance): long-press on \`Compass\` home entry pushes a banner-menu with eight entries (seven actions + Back). Selecting Settings shows "Coming soon" for ~2 s. CAPABILITY_QUERY is not emitted on submenu open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)