### PR TITLE
feat(bd-9-2): wire Find Desire / Calibrate / End Session

### DIFF
--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -49,7 +49,7 @@ void CompassMenu::buildRoot() {
     opts.bannerCallback = [](int selected) -> void {
         switch (selected) {
             case FindDesire:
-                LOG_INFO("Compass menu: Find Desire (stub — bd-9-2)");
+                if (CompassModule::instance) CompassModule::instance->sendCapabilityQuery();
                 break;
             case Treasures:
                 graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
@@ -58,10 +58,19 @@ void CompassMenu::buildRoot() {
                 LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
                 break;
             case Calibrate:
-                LOG_INFO("Compass menu: Calibrate (stub — bd-9-2)");
+                if (CompassModule::instance) {
+                    CompassModule::instance->state()->startCalibration();
+                    CompassModule::instance->notifyUIChanged();
+                }
                 break;
             case EndSession:
-                LOG_INFO("Compass menu: End Session (stub — bd-9-2)");
+                if (CompassModule::instance &&
+                    CompassModule::instance->state()->session().peerNodeNum != 0) {
+                    CompassModule::instance->sendSessionEnd();
+                } else {
+                    CompassMenu::pendingToast = "No active session";
+                    graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
+                }
                 break;
             case Status:
                 LOG_INFO("Compass menu: Status (stub — bd-9-5)");


### PR DESCRIPTION
## Summary
Replaces the bd-9-1 LOG_INFO stubs for three entries with real CompassModule calls, per the TDD's per-bead breakdown.

| Entry | Action |
|---|---|
| Find Desire | \`CompassModule::instance->sendCapabilityQuery()\` |
| Calibrate | \`state()->startCalibration()\` + \`notifyUIChanged()\` |
| End Session | \`sendSessionEnd()\` if \`peerNodeNum != 0\`, else queue "No active session" toast |

The End Session no-peer branch checks state explicitly rather than relying on \`sendSessionEnd\`'s silent no-op — we want a visible toast.

Build: \`heltec-mesh-node-t114\` SUCCESS, Flash 93.7% (+112 bytes vs bd-9-1 baseline).

Refs #9. Closes bd-9-2.

## Test plan
- [x] \`make build\` succeeds.
- [ ] On hardware: \`Find Desire\` → DISCOVERING screen + CAPABILITY_QUERY emitted. \`Calibrate\` → CALIBRATING screen. \`End Session\` while session active → SESSION_END unicast + return to IDLE. \`End Session\` with no session → "No active session" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)