### PR TITLE
feat(bd-9-3,bd-9-4,bd-9-6): Save Treasure / Treasures picker / Settings toast

### DIFF
--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -4,12 +4,15 @@
 #include "CompassMenu.h"
 
 #include "CompassModule.h"
+#include "CompassState.h"
 #include "configuration.h"
 #include "graphics/Screen.h"
 #include "graphics/draw/MenuHandler.h"
+#include "mesh/NodeDB.h"   // localPosition
 
-using compass::CompassMenu;
-using graphics::BannerOverlayOptions;
+#include <stdio.h>
+
+namespace compass {
 
 const char *CompassMenu::pendingToast = nullptr;
 
@@ -41,7 +44,7 @@ void CompassMenu::buildRoot() {
         Calibrate, EndSession, Status, Settings,
     };
 
-    BannerOverlayOptions opts;
+    graphics::BannerOverlayOptions opts;
     opts.message = "Compass";
     opts.optionsArrayPtr = labels;
     opts.optionsEnumPtr = enums;
@@ -54,9 +57,30 @@ void CompassMenu::buildRoot() {
             case Treasures:
                 graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
                 break;
-            case SaveTreasure:
-                LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
+            case SaveTreasure: {
+                // Static buffer for the success-toast message; pointer outlives the
+                // callback because the toast is shown on the next frame.
+                static char savedMsg[24];
+                if (!CompassModule::instance) {
+                    CompassMenu::pendingToast = "Module not ready";
+                } else if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
+                    CompassMenu::pendingToast = "No GPS fix";
+                } else {
+                    char label[13];
+                    const uint32_t now = localPosition.time;
+                    snprintf(label, sizeof(label), "T-%u", static_cast<unsigned>(now % 10000));
+                    const bool saved = CompassModule::instance->state()->saveTreasure(
+                        label, localPosition.latitude_i, localPosition.longitude_i, now);
+                    if (saved) {
+                        snprintf(savedMsg, sizeof(savedMsg), "%s saved", label);
+                        CompassMenu::pendingToast = savedMsg;
+                    } else {
+                        CompassMenu::pendingToast = "Treasures full";
+                    }
+                }
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
                 break;
+            }
             case Calibrate:
                 if (CompassModule::instance) {
                     CompassModule::instance->state()->startCalibration();
@@ -88,20 +112,45 @@ void CompassMenu::buildRoot() {
 }
 
 void CompassMenu::buildTreasures() {
-    // bd-9-4 replaces this stub with a list dynamically built from
-    // CompassModule::instance->state()->treasureCount(). For the
-    // skeleton we just show a placeholder so QA can verify the dispatch
-    // path lands here.
-    static const char *labels[] = {"Back", "(populated in bd-9-4)"};
-    static int enums[] = {0, 1};
+    if (!CompassModule::instance) return;
+    CompassState *st = CompassModule::instance->state();
+    const uint8_t count = st->treasureCount();
 
-    BannerOverlayOptions opts;
+    // Static so pointers / enums outlive the function call. Slot 0 is Back;
+    // slots 1..count point at the live Treasure::label members in
+    // CompassState (which lives forever, so the pointers stay valid).
+    static const char *labels[CompassState::MAX_TREASURES + 1];
+    static int enums[CompassState::MAX_TREASURES + 1];
+
+    labels[0] = "Back";
+    enums[0]  = 0;
+
+    uint8_t entryCount;
+    if (count == 0) {
+        labels[1] = "(no treasures saved)";
+        enums[1]  = -1;   // "empty-state" sentinel; ignored in the callback
+        entryCount = 2;
+    } else {
+        for (uint8_t i = 0; i < count; ++i) {
+            labels[i + 1] = st->treasure(i).label;
+            // Carry the treasure index in the enum value (offset by 1 so 0 = Back).
+            enums[i + 1] = static_cast<int>(i) + 1;
+        }
+        entryCount = static_cast<uint8_t>(count + 1);
+    }
+
+    graphics::BannerOverlayOptions opts;
     opts.message = "Treasures";
     opts.optionsArrayPtr = labels;
     opts.optionsEnumPtr = enums;
-    opts.optionsCount = 2;
-    opts.bannerCallback = [](int /*selected*/) -> void {
-        LOG_INFO("Compass menu: Treasures pick (stub — bd-9-4)");
+    opts.optionsCount = entryCount;
+    opts.bannerCallback = [](int selected) -> void {
+        if (selected <= 0) return;   // Back or empty-state sentinel
+        if (!CompassModule::instance) return;
+        const uint8_t idx = static_cast<uint8_t>(selected - 1);
+        if (idx >= CompassModule::instance->state()->treasureCount()) return;
+        CompassModule::instance->state()->startTreasureNav(idx);
+        CompassModule::instance->notifyUIChanged();
     };
     if (screen) screen->showOverlayBanner(opts);
 }
@@ -111,3 +160,5 @@ void CompassMenu::showPendingToast() {
     CompassMenu::pendingToast = nullptr;
     if (screen) screen->showSimpleBanner(msg, 2000);
 }
+
+} // namespace compass


### PR DESCRIPTION
## Summary
Closes three remaining CompassMenu.cpp beads in one PR — they all touch the same file and a per-bead rebuild for unrelated entry wirings would just be churn.

| bd | What |
|---|---|
| bd-9-3 | Save Treasure entry: "No GPS fix" toast when \`localPosition\` is (0,0). On valid fix, label = \`T-<unix-time-mod-10000>\` (PRD §10.4). "Treasures full" toast when \`saveTreasure\` returns false. Success toast via a static buffer that outlives the callback. |
| bd-9-4 | Treasures picker: dynamic list from \`state()->treasureCount()\`. Labels point at \`Treasure::label\` members directly (CompassState lives forever). Empty state: "(no treasures saved)" with enum sentinel \`-1\` ignored in the callback. |
| bd-9-6 | Settings: already wired in bd-9-1 (queues \`compass_toast\` with "Coming soon"). Closed here for tracking; no incremental code in this PR. |

Build: \`heltec-mesh-node-t114\` SUCCESS, UF2 1529344 bytes (+1024 vs bd-9-2).

Refs #9. Closes bd-9-3, bd-9-4, bd-9-6.

## Test plan
- [x] \`make build\` succeeds.
- [ ] Hardware: Save Treasure with valid GPS shows \`T-NNNN saved\`. With \`lat=0,lon=0\` shows "No GPS fix" and \`treasureCount\` is unchanged. After 5 saves, the 6th attempt shows "Treasures full".
- [ ] Hardware: Treasures picker with empty store shows "(no treasures saved)". With saved entries, selecting one transitions to TRACKING_TREASURE with arrow toward that treasure.
- [ ] Hardware: Settings shows "Coming soon" toast for ~2 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)