### PR TITLE
feat(bd-9-5): Status read-only screen

### DIFF
--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -97,7 +97,10 @@ void CompassMenu::buildRoot() {
                 }
                 break;
             case Status:
-                LOG_INFO("Compass menu: Status (stub — bd-9-5)");
+                if (CompassModule::instance) {
+                    CompassModule::instance->state()->startStatus();
+                    CompassModule::instance->notifyUIChanged();
+                }
                 break;
             case Settings:
                 CompassMenu::pendingToast = "Coming soon";

--- a/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
@@ -247,6 +247,8 @@ int32_t CompassModule::runOnce() {
             return tickTracking();
         case State::TRACKING_TREASURE:
             return 1000;
+        case State::STATUS:
+            return 1000;
     }
     return 1000;
 }

--- a/firmware-overlay/src/modules/CompassModule/CompassState.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassState.cpp
@@ -212,6 +212,12 @@ void CompassState::deleteTreasure(uint8_t i) {
     saveTreasuresFile();
 }
 
+// --- Status -----------------------------------------------------------
+
+void CompassState::startStatus() {
+    setState(State::STATUS);
+}
+
 // --- Calibration ------------------------------------------------------
 
 void CompassState::startCalibration() {

--- a/firmware-overlay/src/modules/CompassModule/CompassState.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassState.h
@@ -21,6 +21,7 @@ enum class State : uint8_t {
     TRACKING_TREASURE,     // Navigating to a saved waypoint
     SESSION_PAUSED,        // No Desire updates for 5min; backgrounded
     CALIBRATING,           // Magnetometer calibration loop
+    STATUS,                // Read-only status screen (any input dismisses)
 };
 
 struct DiscoveredNode {
@@ -98,6 +99,9 @@ public:
     uint8_t         treasureCount() const { return _treasureCount; }
     const Treasure &treasure(uint8_t i) const { return _treasures[i]; }
     void            deleteTreasure(uint8_t i);
+
+    // Status screen (read-only; transitions to IDLE on any input)
+    void     startStatus();
 
     // Calibration
     void     startCalibration();

--- a/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
@@ -48,6 +48,7 @@ bool CompassUI::wantUIFrame() const {
         case State::SESSION_PAUSED:
         case State::TRACKING_TREASURE:
         case State::CALIBRATING:
+        case State::STATUS:
             return true;
         default:
             return false;
@@ -68,6 +69,7 @@ void CompassUI::drawFrame(OLEDDisplay *display, OLEDDisplayUiState * /*state*/, 
         case State::SESSION_PAUSED:     drawSessionPaused(display, x, y);      break;
         case State::TRACKING_TREASURE:  drawTrackingTreasure(display, x, y);   break;
         case State::CALIBRATING:        drawCalibrating(display, x, y);        break;
+        case State::STATUS:             drawStatus(display, x, y);             break;
         default:                                                               break;
     }
 }
@@ -204,6 +206,28 @@ void CompassUI::drawSessionPaused(OLEDDisplay *display, int16_t x, int16_t y) {
     display->drawString(x + 4, y + 50, buf);
 }
 
+void CompassUI::drawStatus(OLEDDisplay *display, int16_t x, int16_t y) {
+    auto *st = _owner->state();
+    auto *mg = _owner->mag();
+    const auto &sess = st->session();
+
+    display->setTextAlignment(TEXT_ALIGN_LEFT);
+    display->drawString(x + 4, y + 0,  "Captain's Compass");
+    display->drawString(x + 4, y + 16, mg->isReady() ? "mag: OK" : "mag: not found");
+
+    char buf[40];
+    if (sess.peerNodeNum != 0) {
+        snprintf(buf, sizeof(buf), "session: %s", sess.peerName[0] ? sess.peerName : "(peer)");
+    } else {
+        snprintf(buf, sizeof(buf), "session: (none)");
+    }
+    display->drawString(x + 4, y + 32, buf);
+    snprintf(buf, sizeof(buf), "treasures: %u", static_cast<unsigned>(st->treasureCount()));
+    display->drawString(x + 4, y + 48, buf);
+    display->drawString(x + 4, y + 64, "port: 300");
+    display->drawString(x + 4, y + 96, "(any input dismisses)");
+}
+
 // --- Arrow ------------------------------------------------------------
 
 void CompassUI::drawArrow(OLEDDisplay *display, int16_t cx, int16_t cy, float headingErrorDeg, bool dim) {
@@ -298,6 +322,16 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
                 // End session and refresh frame list so screen rotation
                 // returns to its normal behavior. The "minimize but keep
                 // tracking" UX is a v2 follow-up (bead -dyg).
+                st->endSession();
+                _owner->notifyUIChanged();
+                return 1;
+            }
+            return 0;
+        }
+        case State::STATUS: {
+            // Any input dismisses the read-only status screen back to home.
+            // endSession() with no active session is just a setState(IDLE).
+            if (e->inputEvent != 0) {
                 st->endSession();
                 _owner->notifyUIChanged();
                 return 1;

--- a/firmware-overlay/src/modules/CompassModule/CompassUI.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassUI.h
@@ -40,6 +40,7 @@ private:
     void drawAwaitingPairAccept(OLEDDisplay *display, int16_t x, int16_t y);
     void drawCalibrating(OLEDDisplay *display, int16_t x, int16_t y);
     void drawSessionPaused(OLEDDisplay *display, int16_t x, int16_t y);
+    void drawStatus(OLEDDisplay *display, int16_t x, int16_t y);
 
     // Arrow rendering: center is the (x,y) origin passed in;
     // headingErrorDeg is signed (positive = clockwise).


### PR DESCRIPTION
## Summary
Adds a STATUS state to the CompassState FSM and a corresponding drawStatus renderer. Wired into the submenu via the Status entry (which until now was a LOG_INFO stub).

Renders four lines:
- \`mag: OK\` / \`mag: not found\`
- \`session: <peerName>\` or \`session: (none)\`
- \`treasures: N\`
- \`port: 300\`

Plus a footer \`(any input dismisses)\`. The dismissal handler calls \`endSession()\`, which is just \`setState(IDLE)\` when no session was active — same pattern CALIBRATING uses for its dismissal.

Files touched: \`CompassState.{h,cpp}\`, \`CompassUI.{h,cpp}\`, \`CompassModule.cpp\`, \`CompassMenu.cpp\`. No \`apply.py\` patches changed (overlay-only).

Build: \`heltec-mesh-node-t114\` SUCCESS, Flash 93.9% (+0.2% vs bd-9-3/4/6), UF2 1530368 bytes.

Refs #9. Closes bd-9-5.

## Test plan
- [x] \`make build\` succeeds.
- [ ] Hardware: Compass → Status pushes the read-only screen showing all four fields. Pressing any user-button input returns to home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)