### PR TITLE
fix(bd-9-7): set loopbackOk=true and self-guard handle* methods

### DIFF
--- a/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
@@ -17,6 +17,16 @@ CompassModule::CompassModule()
     : SinglePortModule("compass", meshtastic_PortNum_COMPASS_APP),
       concurrency::OSThread("Compass") {
     instance = this;
+
+    // Bug 2 fix (issue #9). MeshModule defaults loopbackOk=false, which
+    // causes the dispatcher in MeshModule.cpp:112-115 to early-out on
+    // any RX_SRC_LOCAL delivery — so our own outbound packets never
+    // reach our handleReceived(). For Compass we DO want to see local
+    // loopback (e.g. to confirm our own CAPABILITY_QUERY went out, and
+    // for any future use of unicast-to-self for testing). The self-guards
+    // in each handle* method below prevent infinite echoes.
+    loopbackOk = true;
+
     _state.begin();
     Magnetometer::InitResult magInit = _mag.begin();
     LOG_INFO("Captain's Compass: mag init %s",
@@ -164,13 +174,23 @@ void CompassModule::sendSessionEnd() {
 
 // --- Per-message handlers ---------------------------------------------
 
+// All handle* methods early-out on self-loopback (mp.from == ourNodeNum).
+// Necessary because we set loopbackOk=true in the constructor; without
+// these guards, our own broadcast CAPABILITY_QUERY would be re-handled
+// here as if it came from a peer, generating a CAPABILITY_ADV reply to
+// ourselves (and so on).
+static inline bool _isFromSelf(const meshtastic_MeshPacket &mp) {
+    return nodeDB && mp.from == nodeDB->getNodeNum();
+}
+
 void CompassModule::handleCapabilityQuery(const meshtastic_MeshPacket &mp) {
-    // Anyone running CompassModule responds, regardless of UI state.
+    if (_isFromSelf(mp)) return;
     sendCapabilityAdv(mp.from);
 }
 
 void CompassModule::handleCapabilityAdv(const meshtastic_MeshPacket &mp,
                                         const meshtastic_CompassPacket & /*pkt*/) {
+    if (_isFromSelf(mp)) return;
     if (!_state.isDiscoveryWindowOpen()) return;
     const meshtastic_NodeInfoLite *info = nodeDB ? nodeDB->getMeshNode(mp.from) : nullptr;
     const char *shortName = (info && info->has_user) ? info->user.short_name : "";
@@ -178,11 +198,13 @@ void CompassModule::handleCapabilityAdv(const meshtastic_MeshPacket &mp,
 }
 
 void CompassModule::handlePairRequest(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     _state.onPairRequestReceived(mp.from);
     notifyUIChanged();
 }
 
 void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     const meshtastic_NodeInfoLite *info = nodeDB ? nodeDB->getMeshNode(mp.from) : nullptr;
     const char *peerName = (info && info->has_user) ? info->user.long_name : "";
     _state.onPairAccepted(mp.from, peerName);
@@ -192,10 +214,12 @@ void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
 
 void CompassModule::handlePairConfirm(const meshtastic_MeshPacket &mp) {
     // Desire side: pair handshake complete. Already in TRACKED if we acceptPair'd.
+    if (_isFromSelf(mp)) return;
     (void)mp;
 }
 
-void CompassModule::handlePairReject(const meshtastic_MeshPacket & /*mp*/) {
+void CompassModule::handlePairReject(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     _state.onPairRejected();
     notifyUIChanged();
 }


### PR DESCRIPTION
## Root cause
\`vendor/meshtastic-firmware/src/mesh/MeshModule.cpp:112-115\` explicitly filters out \`RX_SRC_LOCAL\` deliveries unless the module opts in via \`loopbackOk = true\`:

\`\`\`cpp
if ((src == RX_SRC_LOCAL) && !(pi.loopbackOk)) {
    // new case, monitor separately for now, then FIXME merge above
    wantsPacket = false;
}
\`\`\`

\`MeshModule.h:99\` defaults \`loopbackOk = false\`. CompassModule inherited that default, so the dispatcher early-out'd on every loopback delivery — exactly matching the issue #9 log line \`[UserButton] No modules interested in portnum=300, src=LOCAL\`. SinglePortModule's \`wantPacket()\` was a red herring; the loopback was filtered upstream of \`wantPacket()\`.

## Fix
1. Set \`loopbackOk = true\` in the constructor, with a comment explaining why.
2. Add a \`mp.from == nodeDB->getNodeNum()\` early-out to every \`handle*\` method.

The self-guards are necessary because of (1): with \`loopbackOk=true\`, our own broadcast \`CAPABILITY_QUERY\` re-enters \`handleReceived\` → \`handleCapabilityQuery\` → \`sendCapabilityAdv(mp.from)\` where \`mp.from\` is **us**, which loops back into \`handleCapabilityAdv\` etc. \`handleCapabilityQuery\` is the load-bearing one; the others are defensive and cheap.

## Why not just leave \`loopbackOk=false\`?
Two reasons:

1. We may want loopback for testing (unicast-self for round-trip verification of new message types without a second device).
2. The original issue-#9 acceptance criterion is "Sending a Compass packet to self (loopback) is processed by CompassModule::handleReceived(). The 'No modules interested in portnum=...' log line does not appear for that packet." That requires \`loopbackOk=true\` plus the self-guards.

Build: \`heltec-mesh-node-t114\` SUCCESS, UF2 unchanged at 1530368 bytes (self-guards inlined).

Refs #9. Closes bd-9-7.

## Test plan
- [x] \`make build\` succeeds.
- [ ] Hardware: trigger a CAPABILITY_QUERY (Compass → Find Desire). Log shows \`Compass: sent CAPABILITY_QUERY\` followed by \`handleReceived(LOCAL)... Portnum=300\` reaching \`CompassModule\` (no \`No modules interested\`). The self-guard early-outs in \`handleCapabilityQuery\` so no \`CAPABILITY_ADV\` is sent to ourselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)