### PR TITLE
fix(#9): Compass submenu + loopback receive-handler + PortNum doc reconciliation

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.3 ---
+# --- BEGIN BEADS INTEGRATION v1.0.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.3 ---
+# --- END BEADS INTEGRATION v1.0.0 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,33 @@
 {
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  },
   "permissions": {
+    "additionalDirectories": [
+      "/home/nathan/code-stuff/meshtastic-captains-compass",
+      "/home/nathan/code-stuff/meshtastic-firmware/protobufs/meshtastic"
+    ],
     "allow": [
       "Read(*)",
       "Write(*)",
@@ -31,34 +59,6 @@
       "Bash(git commit -m ' *)",
       "Bash(git push *)"
     ],
-    "deny": [],
-    "additionalDirectories": [
-      "/home/nathan/code-stuff/meshtastic-captains-compass",
-      "/home/nathan/code-stuff/meshtastic-firmware/protobufs/meshtastic"
-    ]
-  },
-  "hooks": {
-    "PreCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bd prime"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bd prime"
-          }
-        ]
-      }
-    ]
+    "deny": []
   }
 }

--- a/docs/prd-issue-002-captains-compass.md
+++ b/docs/prd-issue-002-captains-compass.md
@@ -249,7 +249,7 @@ The feature has to be invisible when not in use. A user who never activates Comp
 
 ## 7. Protocol Specification
 
-**Port:** `meshtastic_PortNum_COMPASS_APP` (register with Meshtastic upstream; use reserved range 512–1023 for prototyping)
+**Port:** `meshtastic_PortNum_COMPASS_APP = 300` — chosen from Meshtastic's 256–511 private-app range. Not registered upstream; if Captain's Compass ships beyond this fork, propose a stable allocation against `meshtastic/protobufs#portnums.proto`. (Issue #9 reconciled the prose with the proto; see `docs/tdd-issue-009-compass-submenu.md` §5.)
 
 **Message types** (`compass.proto`):
 

--- a/docs/prd-issue-009-compass-submenu.md
+++ b/docs/prd-issue-009-compass-submenu.md
@@ -1,0 +1,112 @@
+# Issue #9 — Compass Submenu CUJ PRD
+
+**Status:** Draft
+**Owner:** Captain's Compass team
+**Parent issue:** [#9 — Long-press "select" on the Compass menu entry does not open the Compass submenu](https://github.com/soniccyclone/meshtastic-captains-compass/issues/9)
+**Parent PRD:** [`docs/prd-issue-002-captains-compass.md`](./prd-issue-002-captains-compass.md)
+
+---
+
+## 1. Problem Statement
+
+The v0.1 PRD (issue #002) describes every user journey as starting from `Menu → Compass → <action>` — i.e., it assumes a **Compass parent menu with child entries**. The shipped firmware never built that submenu. Instead, the home banner-menu's `Compass` entry was wired directly to `CompassModule::sendCapabilityQuery()`, which silently starts a discovery broadcast.
+
+Effect for the user:
+
+- Long-press USER on the highlighted `Compass` home-menu entry produces no visible UI change. The screen stays on the home menu.
+- A discovery LoRa packet is transmitted, but with no on-screen indication.
+- All five other journeys described in the v0.1 PRD (`Calibrate`, `Save Treasure`, `Treasures`, `End Session`, status check) have **no entry point at all** — there is nowhere in the UI for the user to invoke them.
+
+The visible "long-press does nothing" symptom is the surface; the underlying defect is that the parent-menu node and its children were never wired in.
+
+## 2. Personas
+
+Carried forward from the parent PRD without change. Primary user is a hiking/biking field user on a Heltec T114; secondary is the *Desire* (the person being tracked).
+
+## 3. Scope
+
+**In scope.** The single critical user journey of *getting from the home menu into the Compass feature surface*. Specifically:
+
+- Selecting `Compass` from the home banner-menu pushes a child banner-menu, not a single action.
+- Each child entry routes to either an existing implemented surface or an explicit "not yet implemented" placeholder. No child entry should silently do nothing.
+- Pressing `Back` from the child menu returns to the home menu without side effects.
+
+**Out of scope.** The internals of each child journey (calibration UX, treasure-save UX, etc.) are already specified in the parent PRD's CUJ-1..CUJ-8. This PRD only defines the *menu entry point* for each.
+
+Bugs 2 (PortNum receive-handler not registered) and 3 (PortNum value drift between PRD prose and proto) from issue #9 are implementation concerns — they are tracked here for completeness but their resolution lives in the technical design doc.
+
+## 4. Critical User Journey: Opening the Compass Submenu
+
+**Pre-conditions:** Device is booted and on the home screen rotation. User has not yet entered any Compass surface this session.
+
+**Steps:**
+
+1. Short-press USER repeatedly to open the home banner-menu and scroll until `Compass` is highlighted.
+2. Long-press USER (≥ 1 s) to "select" the `Compass` entry.
+3. The screen pushes a **Compass banner-menu** containing the entries listed in §5. The first entry (`Find Desire`) is highlighted.
+4. Short-press USER to scroll within the Compass menu. Long-press USER to select an entry.
+5. Selecting an entry transitions to that entry's screen (existing entries) or shows a transient `Coming soon` toast and remains on the Compass menu (placeholder entries).
+6. Pressing `Back` (or selecting the `Back` entry) returns to the home banner-menu without sending any LoRa packets and without modifying any persisted state.
+
+**Success state:** User can reach `Find Desire`, `Calibrate`, and `Save Treasure` from the home menu via two long-presses. Every other entry from the parent PRD's vocabulary either works or visibly identifies itself as not-yet-built.
+
+**Logging contract (testability hook):**
+
+- Every time the Compass submenu is *opened*, exactly one `[Screen]` redraw line is emitted within the same second as the `LONG PRESS RELEASE` log line.
+- Opening the submenu does **not** emit `[UserButton] Compass: sent CAPABILITY_QUERY`. The query is sent only when the user explicitly selects `Find Desire` inside the submenu.
+- Opening the submenu does **not** emit `No modules interested in portnum=...`.
+
+## 5. Submenu Inventory
+
+The Compass child banner-menu contains these entries, in this order. Wording matches the parent PRD's CUJ section titles where one exists.
+
+| # | Label              | Action on select                                         | Status (this PR)   | Backing CUJ in parent PRD |
+|---|--------------------|----------------------------------------------------------|--------------------|---------------------------|
+| 1 | `Find Desire`      | Calls `CompassModule::sendCapabilityQuery()` (existing). | Implemented        | CUJ-3                     |
+| 2 | `Treasures`        | Pushes the saved-treasures list. Selecting one starts treasure navigation via `CompassState::startTreasureNav(i)`. | Implemented        | CUJ-6                     |
+| 3 | `Save Treasure`    | Calls `CompassState::saveTreasure(...)` with current GPS position and an auto-generated label. | Implemented        | CUJ-5                     |
+| 4 | `Calibrate`        | Calls `CompassState::startCalibration()` (existing).     | Implemented        | CUJ-2                     |
+| 5 | `End Session`      | Calls `CompassModule::sendSessionEnd()` if a session is active; otherwise shows transient `No active session`. | Implemented        | CUJ-7                     |
+| 6 | `Status`           | Shows magnetometer init result + paired-peer count + treasure count. Read-only screen, dismissed by `Back` or any input. | Implemented (new screen) | CUJ-1                     |
+| 7 | `Settings`         | Shows `Coming soon` toast.                               | Placeholder        | (not yet specified)       |
+| 8 | `Back`             | Returns to home banner-menu.                             | Implemented        | n/a                       |
+
+**Justification for `Status` over the issue-reporter's `Manage`.** The reporter's recall listed `Manage` as one of the entries. The parent PRD never uses that word; CUJ-1 ("First-Time Hardware Setup") describes a status-check journey. We adopt `Status` to align with the parent PRD's vocabulary. `Manage` (paired-peer pruning, treasure deletion UI) is deferred to v0.3 and tracked as a separate issue.
+
+**Justification for `Pair New Desire` collapsing into `Find Desire`.** The reporter listed both. In the parent PRD these are the same journey — discovery is the entry point to pairing. We use the parent PRD's wording (`Find Desire`) and do not duplicate.
+
+## 6. Acceptance Criteria
+
+Tied 1:1 to the issue's acceptance criteria, with logging assertions made explicit.
+
+- [ ] Long-press USER on the home menu's `Compass` entry pushes the Compass banner-menu screen.
+- [ ] The pushed screen contains the entries in §5, in that order.
+- [ ] The `LONG PRESS RELEASE` log line is followed within 1 s by a `[Screen]` redraw line.
+- [ ] Opening the submenu does **not** emit `[UserButton] Compass: sent CAPABILITY_QUERY`.
+- [ ] Pressing `Back` from the submenu returns to the home banner-menu and emits no LoRa packets.
+- [ ] Selecting `Find Desire` emits `Compass: sent CAPABILITY_QUERY` and transitions to the `DISCOVERING` screen (existing behavior).
+- [ ] Selecting `Calibrate` transitions to the `CALIBRATING` screen.
+- [ ] Selecting `Save Treasure` while GPS has a fix calls `CompassState::saveTreasure(...)` and shows a confirmation toast.
+- [ ] Selecting `Save Treasure` *without* a GPS fix shows `No GPS fix` and does not write to flash.
+- [ ] Sending a `CompassPacket` to self (loopback) is processed by `CompassModule::handleReceived()`. The `[ModuleManager] No modules interested in portnum=...` log line does not appear for that packet. (Bug 2 — surface-level acceptance only; root cause analysis lives in the TDD.)
+- [ ] The PortNum value used by the firmware matches the value documented in the parent PRD's §7. (Bug 3 — reconciliation only; the source of truth is the proto, the PRD prose follows.)
+
+## 7. Out of Scope (deferred)
+
+- Full implementation of `Settings`. Tracked as a follow-up bd issue.
+- A `Manage` entry for pruning paired peers / deleting treasures. Tracked as v0.3.
+- Replacing the banner-menu pattern with a richer in-app menu. The banner-menu is consistent with how upstream Meshtastic surfaces all sub-menus (Bluetooth, Mesh, etc.); changing the pattern is a v2 concern.
+- Animations / transitions on submenu push.
+
+## 8. Open Questions
+
+1. **Banner-menu vs full screen takeover for `Status`?** The other entries route to existing full-screen states. `Status` is a new read-only screen. Decision to be made in the TDD; default is "render via the existing module-frame mechanism, dismissed by any input".
+2. **Default selection on submenu open** — sticky (last-used) vs. always `Find Desire`? Default is always `Find Desire` until a user complaint warrants stickiness. (Sticky requires NVS state; not worth the complexity for v0.2.)
+3. **Treasure auto-label format on `Save Treasure`.** Default proposal: `T-<unix-time-mod-10000>`. Bikeshed in TDD review.
+
+## 9. Decisions
+
+- The Compass entry on the home banner-menu pushes a child banner-menu. It does **not** also fire a side-effect packet. (This is the core fix for Bug 1.)
+- The submenu uses the same banner-menu UI primitive as `Mesh`, `Bluetooth`, etc. We do not introduce a new menu pattern.
+- The submenu inventory tracks the parent PRD's CUJ vocabulary, not the issue reporter's recall. Where they disagree, the parent PRD wins and we note the substitution in §5.
+- The PortNum reconciliation (Bug 3) is doc-side only: the firmware proto's value of `300` is correct (in the private-app range as commented in `patches/apply.py`); any prose that implies a different value is stale and gets updated.

--- a/docs/qa-issue-009-compass-submenu.md
+++ b/docs/qa-issue-009-compass-submenu.md
@@ -1,0 +1,261 @@
+# Captain's Compass — Issue #9 Manual QA Test Plan
+
+**Issue:** [#9 — Long-press "select" on the Compass menu entry does not open the Compass submenu](https://github.com/soniccyclone/meshtastic-captains-compass/issues/9)
+**Firmware pin:** `v2.7.15.567b8ea`
+**Audience:** Same audience and ground rules as [`docs/qa-issue-002-captains-compass.md`](./qa-issue-002-captains-compass.md). This plan only covers the issue-#9 fixes; for v0.2-wide regression coverage run that document too.
+
+---
+
+## 0. What this checklist verifies
+
+The three nested defects from issue #9, end-to-end:
+
+- **Bug 1** — Long-press on the home menu's `Compass` entry pushes a banner-menu (it did nothing visible before).
+- **Bug 2** — Local loopback of an outbound Compass packet is processed by `CompassModule::handleReceived()` (was silently dropped before).
+- **Bug 3** — Documented PortNum value matches the firmware's actual value of `300`.
+
+Each test maps 1:1 to a line in [`docs/prd-issue-009-compass-submenu.md`](./prd-issue-009-compass-submenu.md) §6.
+
+## 1. Equipment
+
+Same as the parent QA doc: one T114 (Tests 1–11). A second T114 is **not** required for issue #9 because none of these journeys cross the radio boundary.
+
+You will need a USB-serial console open the entire time. Recommended baud: 115200, line-buffered. Filter for `[UserButton]`, `[ModuleManager]`, `[Screen]`, and `Compass:` log prefixes — that's all you need.
+
+## 2. Pre-flight
+
+| # | Check | Expected |
+|---|---|---|
+| 0.1 | `output/firmware.uf2` exists and was built from the issue-#9 trunk | UF2 matches the SHA in the GitHub Actions artifact for the latest \`feat/9-compass-submenu\` build |
+| 0.2 | T114 in DFU mode, flash UF2, power-cycle | Device boots, home banner shows |
+| 0.3 | Serial console opens, you see `[Screen]` redraw lines on boot | If you don't see these you have a console-buffering problem to fix before continuing |
+
+## 3. Tests
+
+### Test 1 — Submenu opens (Bug 1, primary)
+**Maps to:** PRD §6 line 1 ("Long-press USER on the home menu's `Compass` entry pushes the Compass banner-menu screen.")
+
+**Setup:** On home screen rotation. No active Compass session.
+
+**Steps:**
+1. Short-press USER repeatedly until the home banner-menu appears with `Compass` highlighted.
+2. Long-press USER (≥1 s).
+
+**Expected:**
+- Screen pushes a new banner-menu titled `Compass`.
+- First entry highlighted is `Find Desire`.
+- Within 1 s of the long-press, the serial console shows a `[Screen]` redraw line.
+- Console does **not** show `[UserButton] Compass: sent CAPABILITY_QUERY`.
+- Console does **not** show `No modules interested in portnum=300`.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 2 — Submenu inventory matches PRD §5
+**Maps to:** PRD §6 line 2 ("The pushed screen contains the entries in §5, in that order.")
+
+**Setup:** Compass submenu open from Test 1.
+
+**Steps:**
+1. Short-press USER to scroll through every entry in the submenu, top to bottom.
+
+**Expected, in this order:** `Back`, `Find Desire`, `Treasures`, `Save Treasure`, `Calibrate`, `End Session`, `Status`, `Settings`. Eight entries total.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 3 — Back returns home with no side effects
+**Maps to:** PRD §6 line 5 ("Pressing `Back` from the submenu returns to the home banner-menu and emits no LoRa packets.")
+
+**Setup:** Compass submenu open.
+
+**Steps:**
+1. Scroll to `Back` (or just open the submenu fresh — `Back` is the first entry).
+2. Long-press USER.
+
+**Expected:**
+- Screen returns to home banner-menu.
+- No `[RadioIf] Started Tx` lines in the console between the long-press and the return.
+- No `Compass:` log lines emitted.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 4 — Find Desire transitions to DISCOVERING
+**Maps to:** PRD §6 line 6 ("Selecting `Find Desire` emits `Compass: sent CAPABILITY_QUERY` and transitions to the `DISCOVERING` screen.")
+
+**Setup:** Compass submenu open.
+
+**Steps:**
+1. Scroll to `Find Desire`. Long-press USER.
+
+**Expected:**
+- Screen transitions to the `DISCOVERING` screen (shows `Find Desire` title; either `Searching...` or a list of nearby Compass nodes).
+- Console shows `Compass: sent CAPABILITY_QUERY`.
+- Console shows `[RadioIf] Started Tx (... Portnum=300 ...)`.
+- **NEW (Bug 2 fix):** within ~100 ms of the Tx, console shows the local loopback being delivered to CompassModule. **Specifically, the line `No modules interested in portnum=300, src=LOCAL` should NOT appear.**
+
+Pass / Fail / Notes:
+
+---
+
+### Test 5 — Calibrate transitions to CALIBRATING
+**Maps to:** PRD §6 line 7.
+
+**Setup:** Compass submenu open.
+
+**Steps:**
+1. Scroll to `Calibrate`. Long-press USER.
+
+**Expected:**
+- Screen transitions to the `Calibrating` screen with the sample counter visible.
+- Long-press USER or BACK returns to home menu.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 6 — Save Treasure with valid GPS
+**Maps to:** PRD §6 line 8.
+
+**Setup:** Outdoor location with GPS lock (verify the home screen shows a fix). Compass submenu open.
+
+**Steps:**
+1. Scroll to `Save Treasure`. Long-press USER.
+
+**Expected:**
+- A toast appears for ~2 s: `T-NNNN saved` (where NNNN is unix-time mod 10000).
+- After the toast, screen returns to home banner-menu.
+- Console shows no errors.
+
+**Verification follow-up:**
+2. Re-open Compass submenu → `Treasures`. The new treasure appears in the list.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 7 — Save Treasure without GPS fix
+**Maps to:** PRD §6 line 9.
+
+**Setup:** Indoors / GPS not yet acquired (home screen shows no fix). Compass submenu open.
+
+**Steps:**
+1. Scroll to `Save Treasure`. Long-press USER.
+
+**Expected:**
+- Toast appears for ~2 s: `No GPS fix`.
+- Treasure count is unchanged. (Re-open `Treasures` to verify.)
+
+Pass / Fail / Notes:
+
+---
+
+### Test 8 — Bug 2 self-loopback receives but doesn't echo
+**Maps to:** PRD §6 line 10 ("Sending a `CompassPacket` to self (loopback) is processed by `CompassModule::handleReceived()`. The `[ModuleManager] No modules interested in portnum=...` log line does not appear for that packet.")
+
+**Setup:** No paired peer. Compass submenu open.
+
+**Steps:**
+1. Select `Find Desire`. (This emits a CAPABILITY_QUERY — a self-loopback case.)
+2. Wait 5 seconds.
+3. Long-press BACK to return to home.
+
+**Expected console sequence within ~100 ms of step 1:**
+
+```
+[UserButton] Compass: sent CAPABILITY_QUERY
+[RadioIf] Started Tx (... Portnum=300 ...)
+... handleReceived(LOCAL) ... Portnum=300 ...
+```
+
+**Must NOT appear:**
+
+- `No modules interested in portnum=300, src=LOCAL`
+- A second `Compass: sent CAPABILITY_ADV` to ourselves (the self-guard in `handleCapabilityQuery` short-circuits before the reply).
+
+If the second `CAPABILITY_ADV` line **does** appear, that's a regression in the self-guard — file as a follow-up with the log excerpt.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 9 — Status screen
+**Maps to:** PRD §5 row 6.
+
+**Setup:** Compass submenu open.
+
+**Steps:**
+1. Scroll to `Status`. Long-press USER.
+
+**Expected:**
+- Screen pushes a read-only Status view with four lines:
+  - `mag: OK` *or* `mag: not found` (matches the boot-time mag init log)
+  - `session: (none)` (no active peer)
+  - `treasures: N` (matches the count from Test 6/7)
+  - `port: 300` (literal — matches `compass.proto`)
+- Footer: `(any input dismisses)`.
+2. Press any user-button input.
+
+**Expected:** screen returns to home banner-menu.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 10 — Settings placeholder
+**Maps to:** PRD §5 row 7.
+
+**Setup:** Compass submenu open.
+
+**Steps:**
+1. Scroll to `Settings`. Long-press USER.
+
+**Expected:**
+- Toast appears for ~2 s: `Coming soon`.
+- After the toast, screen returns to home banner-menu.
+
+Pass / Fail / Notes:
+
+---
+
+### Test 11 — Bug 3 doc reconciliation (no hardware needed)
+**Maps to:** PRD §6 line 11.
+
+**Steps:**
+1. Open `docs/prd-issue-002-captains-compass.md` §7.
+
+**Expected:** the prose reads `meshtastic_PortNum_COMPASS_APP = 300 — chosen from Meshtastic's 256–511 private-app range...` (or equivalent). The "512–1023 prototyping range" wording from the original v0.1 PRD is **not** present.
+
+2. Open `firmware-overlay/protobufs/meshtastic/compass.proto`. Confirm the comment header says `port (300)`.
+
+3. `grep -n "COMPASS_APP" patches/apply.py` — confirm the patcher inserts `COMPASS_APP = 300` into upstream's `meshtastic_PortNum`.
+
+Pass / Fail / Notes:
+
+---
+
+## 4. Issue template
+
+If any test fails, copy this into a new GitHub issue:
+
+```markdown
+## QA failure on Captain's Compass issue #9 fix
+
+**Test:** <test number + name from this doc>
+**Hardware:** Heltec T114 rev <2.0 / other>, mag breakout <model>
+**Firmware:** UF2 from <branch / SHA>
+**Expected:** <copy from above>
+**Actual:** <what actually happened>
+
+### Console log (relevant excerpt)
+\`\`\`
+<paste>
+\`\`\`
+
+### Screen photo
+<attach>
+```

--- a/docs/tdd-issue-009-compass-submenu.md
+++ b/docs/tdd-issue-009-compass-submenu.md
@@ -1,0 +1,252 @@
+# Issue #9 — Compass Submenu Technical Design
+
+**Status:** Draft
+**Owner:** Captain's Compass team
+**Implements:** [`docs/prd-issue-009-compass-submenu.md`](./prd-issue-009-compass-submenu.md)
+**Parent TDD:** [`docs/tdd-issue-002-captains-compass.md`](./tdd-issue-002-captains-compass.md)
+
+---
+
+## 1. Scope
+
+This TDD addresses three nested defects surfaced together in [issue #9](https://github.com/soniccyclone/meshtastic-captains-compass/issues/9):
+
+| Bug | Visibility    | Fix locus                                  |
+|-----|---------------|---------------------------------------------|
+| 1   | User-visible  | `patches/apply.py::patch_screen_cpp`, plus a small new `CompassMenu` source-overlay surface |
+| 2   | Log-visible   | `firmware-overlay/src/modules/CompassModule/CompassModule.{h,cpp}` (likely `wantPacket` override) — pending root-cause confirmation against upstream source at the pinned ref |
+| 3   | Doc only      | `docs/prd-issue-002-captains-compass.md` §7                              |
+
+The PRD treats Bug 1 as the headline. Bugs 2 and 3 are caught in the same code path and fixed in the same trunk to avoid issue-fragmentation, but each gets its own bd issue and PR into the trunk.
+
+## 2. Existing Code Map (read before changing anything)
+
+The state of the world today, by file, with line refs against `main` at the time of this TDD's first commit:
+
+- [`firmware-overlay/src/modules/CompassModule/CompassModule.h`](../firmware-overlay/src/modules/CompassModule/CompassModule.h) — declares `CompassModule : public SinglePortModule`. Already exposes `sendCapabilityQuery()`, `sendSessionEnd()`, `notifyUIChanged()`, plus a public `instance` static pointer. The handlers we need to wire from a submenu (`startCalibration`, `saveTreasure`, `startTreasureNav`, `endSession`) live on `CompassState` and are reachable via `CompassModule::instance->state()`.
+- [`firmware-overlay/src/modules/CompassModule/CompassModule.cpp`](../firmware-overlay/src/modules/CompassModule/CompassModule.cpp) — `SinglePortModule("compass", meshtastic_PortNum_COMPASS_APP)` is the registration. `handleReceived()` decodes a `CompassPacket` and dispatches by `pkt.type`. No `wantPacket` override.
+- [`firmware-overlay/src/modules/CompassModule/CompassUI.cpp`](../firmware-overlay/src/modules/CompassModule/CompassUI.cpp) — `handleInputEvent` switches on `state->getState()` and only handles `DISCOVERING`, `PAIR_INCOMING`, `CALIBRATING`, `TRACKING`, `TRACKING_TREASURE`, `SESSION_PAUSED`. There is no `IDLE` case — which is correct: when the home menu is up the module's UI must not eat input. The submenu is therefore *not* a `CompassUI` state; it is an upstream-banner-menu screen pushed by the home menu's callback.
+- [`patches/apply.py::patch_screen_cpp`](../patches/apply.py) — the *current* integration. Three substitutions in `src/graphics/draw/MenuHandler.cpp`:
+  1. enum extension: `Sleep, Compass, enumEnd`
+  2. options-array entry: `optionsArray[options] = "Compass"; optionsEnumArray[options++] = Compass;`
+  3. bannerCallback case: `else if (selected == Compass) { CompassModule::instance->sendCapabilityQuery(); }` ← **this is Bug 1**
+- [`firmware-overlay/protobufs/meshtastic/compass.proto`](../firmware-overlay/protobufs/meshtastic/compass.proto) — header comment says "port (300)". Patch in `patches/apply.py::patch_portnums_proto` adds `COMPASS_APP = 300;` to upstream's `meshtastic_PortNum` enum, in the private-app range 256–511.
+
+## 3. Bug 1 — Architectural Fix
+
+### 3.1 Root cause
+
+The home menu's `Compass` entry was wired as a *terminal action* (fires `sendCapabilityQuery()`), not as a *submenu pusher*. The parent PRD's CUJ-1..CUJ-8 every assume `Menu → Compass → <child>`, and the implementation conflated `Compass` (the parent) with `Find Desire` (one specific child).
+
+### 3.2 Fix shape
+
+Replace the home menu's `Compass` callback with a call into a new `CompassMenu` overlay class that:
+
+1. Builds an `optionsArray` / `optionsEnumArray` for the seven entries from PRD §5.
+2. Calls upstream's banner-menu primitive to push itself onto the screen with its own `bannerCallback` lambda.
+3. In its callback, maps each entry to one of:
+   - `CompassModule::instance->sendCapabilityQuery()` for `Find Desire`
+   - `CompassModule::instance->state()->startCalibration(); CompassModule::instance->notifyUIChanged()` for `Calibrate`
+   - `CompassModule::instance->state()->saveTreasure(label, lat, lon, ts)` for `Save Treasure` (with toast on success / `No GPS fix` on failure)
+   - A nested treasure-list submenu for `Treasures` (entries dynamically built from `state()->treasureCount()`; selecting one calls `state()->startTreasureNav(i)` then `notifyUIChanged()`)
+   - `CompassModule::instance->sendSessionEnd()` for `End Session` (no-op + toast if no active session)
+   - A new full-screen `Status` view (see §3.4) for `Status`
+   - A `Coming soon` toast for `Settings`
+
+The existing `Compass` enum entry, options-array slot, and `Compass` home-menu label all stay; only the callback body changes.
+
+### 3.3 Why an overlay class instead of a third entry in `patch_screen_cpp`
+
+Two reasons:
+
+1. **Patch readability.** The seven-entry callback body is ~80 lines. Inlining 80 lines of generated string concatenation into `apply.py` makes the patch unreviewable. Pulling the body into `firmware-overlay/src/modules/CompassModule/CompassMenu.{h,cpp}` lets `patch_screen_cpp`'s callback stay a one-liner: `CompassMenu::open();`.
+2. **Single source of truth for the inventory.** The submenu inventory is a product fact (PRD §5). It belongs in code that's part of the overlay, not in a Python string buried in `apply.py`. Future entry additions become one-file edits.
+
+The `firmware-overlay/src/modules/Modules.cpp` patch already includes `CompassModule.h`; we extend the Modules.cpp include with `CompassMenu.h` (one extra line in `patch_modules_cpp`) so the home-menu callback's `CompassMenu::open()` symbol resolves.
+
+### 3.4 `Status` screen
+
+A new `CompassUI` state (`STATUS`) plus a `drawStatus()` renderer. Read-only:
+
+```
+Captain's Compass — Status
+mag: OK            (or NOT_FOUND / INIT_FAILED)
+peers: 0           (paired-peer count from CompassState)
+treasures: 0       (CompassState::treasureCount())
+port: 300          (literal — ties to Bug 3 reconciliation)
+```
+
+`STATUS` is added to `wantUIFrame()` and `interceptingKeyboardInput()` so any input (or BACK) returns to home. State is set by the menu callback via a new `CompassState::startStatus()` and cleared on input.
+
+### 3.5 Banner-menu primitive — implementation-phase discovery
+
+The exact upstream call to "push a banner-menu" depends on `MenuHandler.cpp` at the pinned firmware ref `v2.7.15.567b8ea`. The implementation bd issue starts with `make setup` to fetch firmware source, then reads `MenuHandler.cpp` to find:
+
+1. The signature for setting up a transient banner-menu (probably along the lines of how `Bluetooth` or `Mesh` parent entries push their children — locate by grepping for entries with submenus).
+2. Whether banner-menus stack natively or require manual back-handling.
+3. The toast / transient-message API used by upstream (for `Coming soon`, `No GPS fix`, `No active session`).
+
+The TDD does not pre-commit to specific symbol names because the patch system's anchor-substitution model means we need to verify against the actual ref before naming things. **The implementation issue's first acceptance criterion is "documented the upstream API for `Bluetooth`'s submenu push and re-used the same primitive."**
+
+## 4. Bug 2 — Loopback Receive-Handler
+
+### 4.1 Symptom
+
+```
+[UserButton] handleReceived(LOCAL) (... Portnum=300 ...)
+[UserButton] No modules interested in portnum=300, src=LOCAL
+```
+
+This fires on the local loopback of the device's *own* outbound `CAPABILITY_QUERY`. The "no modules interested" line means no module's `wantPacket()` returned true for this packet under whatever filter the local-loopback dispatcher uses.
+
+### 4.2 What we know without firmware source on disk
+
+- `CompassModule` derives from `SinglePortModule("compass", meshtastic_PortNum_COMPASS_APP)`. The default `SinglePortModule::wantPacket` (per upstream conventions) is `return p->decoded.portnum == ourPortNum;` and `ourPortNum = 300`. Both the module's claimed port and the inbound packet's port are 300, so a naïve `wantPacket` match should succeed.
+- The outbound packet has `Portnum=300` in its log, so `ourPortNum` is set correctly at construction time. The module is alive and registered.
+- Therefore the filter that's rejecting this is *not* a portnum mismatch. Most likely candidates:
+  1. **Self-source filter.** Upstream may exclude packets where `mp.from == nodeDB->getNodeNum()` to prevent infinite echoes. Local-loopback is by definition self-sourced.
+  2. **Broadcast-address filter on local source.** The packet's `to` is `0xffffffff`. Upstream may not deliver broadcast packets back to local modules even if a module wants the portnum.
+  3. **`src=LOCAL` short-circuit.** The `RX_SRC_LOCAL` enum value may bypass module dispatch entirely for some packet shapes.
+
+### 4.3 Investigation plan (first commit on the impl branch)
+
+1. `make setup` — fetch the pinned firmware source.
+2. `grep -nR "No modules interested" vendor/meshtastic-firmware/src` — find the log call site.
+3. Read the function containing it. Identify which filter (`wantPacket` return, source filter, address filter) caused the early-out.
+4. Decide the fix:
+   - If the filter is *intended* and our use case is the exception, override `CompassModule::wantPacket` (or whichever method is checked) to return true for our packets even on the LOCAL path.
+   - If the filter is *not intended* and just hasn't been exercised, fix it upstream and patch via `patches/apply.py` (preferring an overlay-only fix if at all possible to avoid forking upstream behavior).
+
+### 4.4 Acceptance evidence
+
+After the fix, on a local-loopback, the log should show the CompassModule's `handleReceived()` running on its own outbound packet — i.e., `handleCapabilityQuery(self) → sendCapabilityAdv(self)`. To prevent infinite echoes, `handleCapabilityQuery` must early-out when `mp.from == nodeDB->getNodeNum()`. That guard is added in the same commit as the receive-filter fix.
+
+```cpp
+void CompassModule::handleCapabilityQuery(const meshtastic_MeshPacket &mp) {
+    if (nodeDB && mp.from == nodeDB->getNodeNum()) return;   // self-loopback, ignore
+    sendCapabilityAdv(mp.from);
+}
+```
+
+(Same self-guard added defensively to all `handle*` methods that send a reply.)
+
+## 5. Bug 3 — Doc Reconciliation
+
+The parent PRD `docs/prd-issue-002-captains-compass.md` §7 currently reads:
+
+> **Port:** `meshtastic_PortNum_COMPASS_APP` (register with Meshtastic upstream; use reserved range 512–1023 for prototyping)
+
+The proto patch (`patches/apply.py::patch_portnums_proto`) places the port at `300`, in Meshtastic's **256–511 private-app range** — not the 512–1023 range the PRD prose mentions. The proto-side comment in `apply.py` is correct ("private-app range; not registered upstream"). The PRD prose is the stale piece.
+
+Fix: update PRD §7 to read:
+
+> **Port:** `meshtastic_PortNum_COMPASS_APP = 300` — chosen from Meshtastic's 256–511 private-app range. Not registered upstream; if Captain's Compass ships beyond this fork, propose a stable allocation against `meshtastic/protobufs#portnums.proto`.
+
+This is a one-paragraph change. It lands as part of the same trunk merge as Bug 2's code fix, so the doc and the proto agree at every commit on `main`.
+
+## 6. Patch System Changes
+
+`patches/apply.py` modifications:
+
+### 6.1 `patch_modules_cpp`
+Extend the include block to also include `CompassMenu.h`:
+
+```python
+text = text.replace(
+    include_anchor,
+    include_anchor + f'\n// {MARKER}\n'
+    '#include "modules/CompassModule/CompassModule.h"\n'
+    '#include "modules/CompassModule/CompassMenu.h"',
+    1,
+)
+```
+
+No new statement in `setupModules()` — the menu is opened lazily on user input, no construction needed at boot.
+
+### 6.2 `patch_screen_cpp`
+Replace the bannerCallback case body. Before:
+
+```python
+cb_replacement = (
+    cb_anchor + " "
+    f"/* {MARKER} */ else if (selected == Compass) {{\n"
+    "            if (CompassModule::instance) {\n"
+    "                CompassModule::instance->sendCapabilityQuery();\n"
+    "            }\n"
+    "        }"
+)
+```
+
+After:
+
+```python
+cb_replacement = (
+    cb_anchor + " "
+    f"/* {MARKER} */ else if (selected == Compass) {{\n"
+    "            CompassMenu::open();\n"
+    "        }"
+)
+```
+
+`CompassMenu::open()` does its own `nullptr` check on `CompassModule::instance` and is a no-op if the module isn't constructed (defensive — shouldn't happen given setupModules() ordering, but cheap to guard).
+
+The include anchor in `patch_screen_cpp` already pulls in `CompassModule.h`; we extend it to also pull `CompassMenu.h`.
+
+### 6.3 No new top-level patches
+Bug 2's fix is overlay-only (lives in `firmware-overlay/`). Bug 3 is doc-only. The patch system gains no new entry points.
+
+## 7. File Changes Summary
+
+```
++ firmware-overlay/src/modules/CompassModule/CompassMenu.h            (~40 lines: open(), CompassMenu class)
++ firmware-overlay/src/modules/CompassModule/CompassMenu.cpp          (~120 lines: 7 entries + dispatch)
+M firmware-overlay/src/modules/CompassModule/CompassModule.cpp        (+~10 lines: self-loopback guards in handle* methods, wantPacket override if §4.3 finds it needed)
+M firmware-overlay/src/modules/CompassModule/CompassModule.h          (+1 line if wantPacket is overridden)
+M firmware-overlay/src/modules/CompassModule/CompassUI.cpp            (+~30 lines: drawStatus, STATUS-state input handling)
+M firmware-overlay/src/modules/CompassModule/CompassUI.h              (+1 method declaration)
+M firmware-overlay/src/modules/CompassModule/CompassState.cpp         (+~5 lines: startStatus())
+M firmware-overlay/src/modules/CompassModule/CompassState.h           (+~3 lines: STATUS enum value, startStatus decl)
+M patches/apply.py                                                    (~10 lines net: include extension, callback body swap)
+M docs/prd-issue-002-captains-compass.md                              (~3 lines: §7 PortNum prose)
++ docs/qa-issue-009-compass-submenu.md                                (manual QA test plan, mirrors §6 of the CUJ PRD's acceptance criteria)
+```
+
+## 8. Bead Breakdown
+
+Each bead is one PR into `feat/9-compass-submenu`. Listed in dependency order; deps modeled in beads.
+
+- **bd-9-1 — Submenu skeleton.** New `CompassMenu.{h,cpp}`. Stubs all seven callbacks to `LOG_INFO("Compass menu: %s clicked")`. Wire `patch_screen_cpp` to call `CompassMenu::open()`. Acceptance: long-press on `Compass` opens a banner-menu with all seven entries; selecting any entry logs and returns to home menu.
+- **bd-9-2 — Wire existing actions.** `Find Desire` → `sendCapabilityQuery`. `Calibrate` → `state()->startCalibration() + notifyUIChanged()`. `End Session` → `sendSessionEnd()` (no-op + toast if no peer). Depends on bd-9-1.
+- **bd-9-3 — `Save Treasure` action.** Calls `state()->saveTreasure(...)` with auto-label, current GPS, current time. Toast on success; `No GPS fix` if `localPosition.latitude_i == 0 && longitude_i == 0`. Depends on bd-9-1.
+- **bd-9-4 — `Treasures` nested submenu.** Build entries dynamically from `state()->treasureCount()`. Selecting an entry calls `state()->startTreasureNav(i) + notifyUIChanged()`. Empty state shows a `No treasures saved` entry. Depends on bd-9-1.
+- **bd-9-5 — `Status` screen.** New `STATUS` state in CompassState/CompassUI. `drawStatus()` renderer. Any input or BACK returns to home. Depends on bd-9-1.
+- **bd-9-6 — `Settings` placeholder.** `Coming soon` toast. Depends on bd-9-1. Trivial; can ride along with bd-9-1 if reviewer prefers.
+- **bd-9-7 — Bug 2 root-cause + fix.** `make setup` + investigation per §4.3. Lands the `wantPacket`/handler-guard fix and the corresponding test evidence (paste of fixed log lines into the bd issue's notes). Independent of bd-9-1..bd-9-6 — can land in parallel.
+- **bd-9-8 — Bug 3 PRD prose update.** Three-line edit to `prd-issue-002-captains-compass.md` §7. Depends on bd-9-7's actual landed PortNum value being `300` (no-op confirmation step before merge).
+- **bd-9-9 — QA test plan.** New `docs/qa-issue-009-compass-submenu.md` mirroring CUJ PRD §6 acceptance criteria as a manual test checklist. Depends on bd-9-1..bd-9-7 closed (test plan needs the actual UX to mirror).
+- **bd-9-10 — Trunk → main PR.** After all above are closed and trunk is green, open `feat/9-compass-submenu` → `main` PR. Closes #9.
+
+## 9. Test Plan
+
+Hardware-only — there is no Portduino smoke test for the menu pipeline at this firmware ref. Manual QA on a T114, captured in `docs/qa-issue-009-compass-submenu.md` (bd-9-9).
+
+Pre-merge gate per bead:
+1. `make build` succeeds.
+2. UF2 flashes.
+3. The bead's specific acceptance criterion (PRD §6 line) is observably true on the device, with the relevant log line pasted into the bd issue's notes.
+
+## 10. Open Questions
+
+1. **Banner-menu primitive.** Resolved by reading `MenuHandler.cpp` at the pinned ref before bd-9-1 starts. If upstream doesn't expose a clean "push child menu" API, fallback is a custom `CompassMenu` screen subclass that owns its own input intercept — uglier but feasible.
+2. **Toast primitive.** Same — discover from `MenuHandler.cpp` or fall back to a 2-second `CompassUI` state for transient messages.
+3. **`Status` screen vs. banner-menu.** The PRD §8 noted this is a TDD decision. Going with a CompassUI state (full screen, dismissed by any input). Banner-menu would force a pseudo-entry just for the back action; the full-screen path is cleaner and matches `CALIBRATING`'s pattern.
+4. **`Save Treasure` label.** Going with `T-<unix-time-mod-10000>` per PRD §8.3 default. Future bd issue can add a label-edit screen if users complain.
+
+## 11. Risk Register
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|----|------|------------|--------|------------|
+| R-9-1 | `MenuHandler.cpp` at v2.7.15.567b8ea has no clean "push submenu" primitive | Medium | Medium | Fallback custom `CompassMenu` screen subclass with its own input intercept (§3.5). Ugly but unblocked. |
+| R-9-2 | Bug 2's filter is in upstream code we don't want to fork | Low | High | Prefer overlay-side `wantPacket` override; only patch upstream if no overlay path works. |
+| R-9-3 | `patch_screen_cpp` anchors drift in a future firmware bump | Low | Low | Existing `--dry-run` mode already detects drift; CI runs it weekly. |
+| R-9-4 | Treasure-list submenu hits banner-menu's max-entries limit on a device with many treasures | Very Low | Low | Cap at first N entries; show a `… more` entry. Out of scope for v0.2 unless `MAX_TREASURES` is already > banner-menu max. Verify in bd-9-4. |

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -1,0 +1,104 @@
+// Captain's Compass — submenu implementation.
+// See docs/tdd-issue-009-compass-submenu.md §3.
+
+#include "CompassMenu.h"
+
+#include "CompassModule.h"
+#include "configuration.h"
+#include "graphics/Screen.h"
+#include "graphics/draw/MenuHandler.h"
+
+using compass::CompassMenu;
+using graphics::BannerOverlayOptions;
+
+const char *CompassMenu::pendingToast = nullptr;
+
+void CompassMenu::open() {
+    graphics::menuHandler::menuQueue = graphics::menuHandler::compass_menu;
+}
+
+void CompassMenu::buildRoot() {
+    // Order and labels are the source of truth for PRD §5. If you change
+    // either here, also update prd-issue-009-compass-submenu.md §5.
+    enum opt {
+        Back,
+        FindDesire,
+        Treasures,
+        SaveTreasure,
+        Calibrate,
+        EndSession,
+        Status,
+        Settings,
+        enumEnd,
+    };
+
+    static const char *labels[enumEnd] = {
+        "Back", "Find Desire", "Treasures", "Save Treasure",
+        "Calibrate", "End Session", "Status", "Settings",
+    };
+    static int enums[enumEnd] = {
+        Back, FindDesire, Treasures, SaveTreasure,
+        Calibrate, EndSession, Status, Settings,
+    };
+
+    BannerOverlayOptions opts;
+    opts.message = "Compass";
+    opts.optionsArrayPtr = labels;
+    opts.optionsEnumPtr = enums;
+    opts.optionsCount = enumEnd;
+    opts.bannerCallback = [](int selected) -> void {
+        switch (selected) {
+            case FindDesire:
+                LOG_INFO("Compass menu: Find Desire (stub — bd-9-2)");
+                break;
+            case Treasures:
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
+                break;
+            case SaveTreasure:
+                LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
+                break;
+            case Calibrate:
+                LOG_INFO("Compass menu: Calibrate (stub — bd-9-2)");
+                break;
+            case EndSession:
+                LOG_INFO("Compass menu: End Session (stub — bd-9-2)");
+                break;
+            case Status:
+                LOG_INFO("Compass menu: Status (stub — bd-9-5)");
+                break;
+            case Settings:
+                CompassMenu::pendingToast = "Coming soon";
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
+                break;
+            case Back:
+            default:
+                break;
+        }
+    };
+    if (screen) screen->showOverlayBanner(opts);
+}
+
+void CompassMenu::buildTreasures() {
+    // bd-9-4 replaces this stub with a list dynamically built from
+    // CompassModule::instance->state()->treasureCount(). For the
+    // skeleton we just show a placeholder so QA can verify the dispatch
+    // path lands here.
+    static const char *labels[] = {"Back", "(populated in bd-9-4)"};
+    static int enums[] = {0, 1};
+
+    BannerOverlayOptions opts;
+    opts.message = "Treasures";
+    opts.optionsArrayPtr = labels;
+    opts.optionsEnumPtr = enums;
+    opts.optionsCount = 2;
+    opts.bannerCallback = [](int /*selected*/) -> void {
+        LOG_INFO("Compass menu: Treasures pick (stub — bd-9-4)");
+    };
+    if (screen) screen->showOverlayBanner(opts);
+}
+
+void CompassMenu::showPendingToast() {
+    const char *msg = CompassMenu::pendingToast ? CompassMenu::pendingToast : "";
+    CompassMenu::pendingToast = nullptr;
+    if (screen) screen->showSimpleBanner(msg, 2000);
+}

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -4,12 +4,15 @@
 #include "CompassMenu.h"
 
 #include "CompassModule.h"
+#include "CompassState.h"
 #include "configuration.h"
 #include "graphics/Screen.h"
 #include "graphics/draw/MenuHandler.h"
+#include "mesh/NodeDB.h"   // localPosition
 
-using compass::CompassMenu;
-using graphics::BannerOverlayOptions;
+#include <stdio.h>
+
+namespace compass {
 
 const char *CompassMenu::pendingToast = nullptr;
 
@@ -41,7 +44,7 @@ void CompassMenu::buildRoot() {
         Calibrate, EndSession, Status, Settings,
     };
 
-    BannerOverlayOptions opts;
+    graphics::BannerOverlayOptions opts;
     opts.message = "Compass";
     opts.optionsArrayPtr = labels;
     opts.optionsEnumPtr = enums;
@@ -54,9 +57,30 @@ void CompassMenu::buildRoot() {
             case Treasures:
                 graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
                 break;
-            case SaveTreasure:
-                LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
+            case SaveTreasure: {
+                // Static buffer for the success-toast message; pointer outlives the
+                // callback because the toast is shown on the next frame.
+                static char savedMsg[24];
+                if (!CompassModule::instance) {
+                    CompassMenu::pendingToast = "Module not ready";
+                } else if (localPosition.latitude_i == 0 && localPosition.longitude_i == 0) {
+                    CompassMenu::pendingToast = "No GPS fix";
+                } else {
+                    char label[13];
+                    const uint32_t now = localPosition.time;
+                    snprintf(label, sizeof(label), "T-%u", static_cast<unsigned>(now % 10000));
+                    const bool saved = CompassModule::instance->state()->saveTreasure(
+                        label, localPosition.latitude_i, localPosition.longitude_i, now);
+                    if (saved) {
+                        snprintf(savedMsg, sizeof(savedMsg), "%s saved", label);
+                        CompassMenu::pendingToast = savedMsg;
+                    } else {
+                        CompassMenu::pendingToast = "Treasures full";
+                    }
+                }
+                graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
                 break;
+            }
             case Calibrate:
                 if (CompassModule::instance) {
                     CompassModule::instance->state()->startCalibration();
@@ -88,20 +112,45 @@ void CompassMenu::buildRoot() {
 }
 
 void CompassMenu::buildTreasures() {
-    // bd-9-4 replaces this stub with a list dynamically built from
-    // CompassModule::instance->state()->treasureCount(). For the
-    // skeleton we just show a placeholder so QA can verify the dispatch
-    // path lands here.
-    static const char *labels[] = {"Back", "(populated in bd-9-4)"};
-    static int enums[] = {0, 1};
+    if (!CompassModule::instance) return;
+    CompassState *st = CompassModule::instance->state();
+    const uint8_t count = st->treasureCount();
 
-    BannerOverlayOptions opts;
+    // Static so pointers / enums outlive the function call. Slot 0 is Back;
+    // slots 1..count point at the live Treasure::label members in
+    // CompassState (which lives forever, so the pointers stay valid).
+    static const char *labels[CompassState::MAX_TREASURES + 1];
+    static int enums[CompassState::MAX_TREASURES + 1];
+
+    labels[0] = "Back";
+    enums[0]  = 0;
+
+    uint8_t entryCount;
+    if (count == 0) {
+        labels[1] = "(no treasures saved)";
+        enums[1]  = -1;   // "empty-state" sentinel; ignored in the callback
+        entryCount = 2;
+    } else {
+        for (uint8_t i = 0; i < count; ++i) {
+            labels[i + 1] = st->treasure(i).label;
+            // Carry the treasure index in the enum value (offset by 1 so 0 = Back).
+            enums[i + 1] = static_cast<int>(i) + 1;
+        }
+        entryCount = static_cast<uint8_t>(count + 1);
+    }
+
+    graphics::BannerOverlayOptions opts;
     opts.message = "Treasures";
     opts.optionsArrayPtr = labels;
     opts.optionsEnumPtr = enums;
-    opts.optionsCount = 2;
-    opts.bannerCallback = [](int /*selected*/) -> void {
-        LOG_INFO("Compass menu: Treasures pick (stub — bd-9-4)");
+    opts.optionsCount = entryCount;
+    opts.bannerCallback = [](int selected) -> void {
+        if (selected <= 0) return;   // Back or empty-state sentinel
+        if (!CompassModule::instance) return;
+        const uint8_t idx = static_cast<uint8_t>(selected - 1);
+        if (idx >= CompassModule::instance->state()->treasureCount()) return;
+        CompassModule::instance->state()->startTreasureNav(idx);
+        CompassModule::instance->notifyUIChanged();
     };
     if (screen) screen->showOverlayBanner(opts);
 }
@@ -111,3 +160,5 @@ void CompassMenu::showPendingToast() {
     CompassMenu::pendingToast = nullptr;
     if (screen) screen->showSimpleBanner(msg, 2000);
 }
+
+} // namespace compass

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -49,7 +49,7 @@ void CompassMenu::buildRoot() {
     opts.bannerCallback = [](int selected) -> void {
         switch (selected) {
             case FindDesire:
-                LOG_INFO("Compass menu: Find Desire (stub — bd-9-2)");
+                if (CompassModule::instance) CompassModule::instance->sendCapabilityQuery();
                 break;
             case Treasures:
                 graphics::menuHandler::menuQueue = graphics::menuHandler::compass_treasure_picker;
@@ -58,10 +58,19 @@ void CompassMenu::buildRoot() {
                 LOG_INFO("Compass menu: Save Treasure (stub — bd-9-3)");
                 break;
             case Calibrate:
-                LOG_INFO("Compass menu: Calibrate (stub — bd-9-2)");
+                if (CompassModule::instance) {
+                    CompassModule::instance->state()->startCalibration();
+                    CompassModule::instance->notifyUIChanged();
+                }
                 break;
             case EndSession:
-                LOG_INFO("Compass menu: End Session (stub — bd-9-2)");
+                if (CompassModule::instance &&
+                    CompassModule::instance->state()->session().peerNodeNum != 0) {
+                    CompassModule::instance->sendSessionEnd();
+                } else {
+                    CompassMenu::pendingToast = "No active session";
+                    graphics::menuHandler::menuQueue = graphics::menuHandler::compass_toast;
+                }
                 break;
             case Status:
                 LOG_INFO("Compass menu: Status (stub — bd-9-5)");

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.cpp
@@ -97,7 +97,10 @@ void CompassMenu::buildRoot() {
                 }
                 break;
             case Status:
-                LOG_INFO("Compass menu: Status (stub — bd-9-5)");
+                if (CompassModule::instance) {
+                    CompassModule::instance->state()->startStatus();
+                    CompassModule::instance->notifyUIChanged();
+                }
                 break;
             case Settings:
                 CompassMenu::pendingToast = "Coming soon";

--- a/firmware-overlay/src/modules/CompassModule/CompassMenu.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassMenu.h
@@ -1,0 +1,42 @@
+// Captain's Compass — submenu (the screen pushed by the home banner-menu's
+// `Compass` entry). See docs/tdd-issue-009-compass-submenu.md §3.
+//
+// The class is a function bag: all members are static. Lifetime is "forever";
+// no instance, no allocation. Two reasons:
+//   1. The banner-menu API (BannerOverlayOptions::bannerCallback) is a
+//      std::function captured at showOverlayBanner() time, so callbacks must
+//      either be capture-less lambdas or reference globals. Statics fit.
+//   2. There is exactly one Compass submenu surface; modeling it as a class
+//      with state would just be ceremony.
+//
+// Re-entrance: never call `screen->showOverlayBanner(...)` from inside another
+// banner's callback — upstream's NotificationRenderer assumes the previous
+// banner is closing when a callback fires. To open another submenu, set
+// `graphics::menuHandler::menuQueue` and let the next frame's
+// `handleMenuSwitch` dispatch the build function. This is the same pattern
+// `systemBaseMenu`, `loraMenu`, etc. use upstream.
+
+#pragma once
+
+#include "configuration.h"
+
+namespace compass {
+
+class CompassMenu {
+public:
+    // Called from the home banner-menu's `Compass` callback. Queues the
+    // root submenu for the next frame.
+    static void open();
+
+    // Dispatch entry points called from `menuHandler::handleMenuSwitch`
+    // patched cases. See patches/apply.py::patch_screen_cpp.
+    static void buildRoot();
+    static void buildTreasures();
+    static void showPendingToast();
+
+    // Set by callbacks before queueing `compass_toast`. Lives across one
+    // frame (set in callback, read in dispatch case, never both).
+    static const char *pendingToast;
+};
+
+} // namespace compass

--- a/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
@@ -247,6 +247,8 @@ int32_t CompassModule::runOnce() {
             return tickTracking();
         case State::TRACKING_TREASURE:
             return 1000;
+        case State::STATUS:
+            return 1000;
     }
     return 1000;
 }

--- a/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassModule.cpp
@@ -17,6 +17,16 @@ CompassModule::CompassModule()
     : SinglePortModule("compass", meshtastic_PortNum_COMPASS_APP),
       concurrency::OSThread("Compass") {
     instance = this;
+
+    // Bug 2 fix (issue #9). MeshModule defaults loopbackOk=false, which
+    // causes the dispatcher in MeshModule.cpp:112-115 to early-out on
+    // any RX_SRC_LOCAL delivery — so our own outbound packets never
+    // reach our handleReceived(). For Compass we DO want to see local
+    // loopback (e.g. to confirm our own CAPABILITY_QUERY went out, and
+    // for any future use of unicast-to-self for testing). The self-guards
+    // in each handle* method below prevent infinite echoes.
+    loopbackOk = true;
+
     _state.begin();
     Magnetometer::InitResult magInit = _mag.begin();
     LOG_INFO("Captain's Compass: mag init %s",
@@ -164,13 +174,23 @@ void CompassModule::sendSessionEnd() {
 
 // --- Per-message handlers ---------------------------------------------
 
+// All handle* methods early-out on self-loopback (mp.from == ourNodeNum).
+// Necessary because we set loopbackOk=true in the constructor; without
+// these guards, our own broadcast CAPABILITY_QUERY would be re-handled
+// here as if it came from a peer, generating a CAPABILITY_ADV reply to
+// ourselves (and so on).
+static inline bool _isFromSelf(const meshtastic_MeshPacket &mp) {
+    return nodeDB && mp.from == nodeDB->getNodeNum();
+}
+
 void CompassModule::handleCapabilityQuery(const meshtastic_MeshPacket &mp) {
-    // Anyone running CompassModule responds, regardless of UI state.
+    if (_isFromSelf(mp)) return;
     sendCapabilityAdv(mp.from);
 }
 
 void CompassModule::handleCapabilityAdv(const meshtastic_MeshPacket &mp,
                                         const meshtastic_CompassPacket & /*pkt*/) {
+    if (_isFromSelf(mp)) return;
     if (!_state.isDiscoveryWindowOpen()) return;
     const meshtastic_NodeInfoLite *info = nodeDB ? nodeDB->getMeshNode(mp.from) : nullptr;
     const char *shortName = (info && info->has_user) ? info->user.short_name : "";
@@ -178,11 +198,13 @@ void CompassModule::handleCapabilityAdv(const meshtastic_MeshPacket &mp,
 }
 
 void CompassModule::handlePairRequest(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     _state.onPairRequestReceived(mp.from);
     notifyUIChanged();
 }
 
 void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     const meshtastic_NodeInfoLite *info = nodeDB ? nodeDB->getMeshNode(mp.from) : nullptr;
     const char *peerName = (info && info->has_user) ? info->user.long_name : "";
     _state.onPairAccepted(mp.from, peerName);
@@ -192,10 +214,12 @@ void CompassModule::handlePairAccept(const meshtastic_MeshPacket &mp) {
 
 void CompassModule::handlePairConfirm(const meshtastic_MeshPacket &mp) {
     // Desire side: pair handshake complete. Already in TRACKED if we acceptPair'd.
+    if (_isFromSelf(mp)) return;
     (void)mp;
 }
 
-void CompassModule::handlePairReject(const meshtastic_MeshPacket & /*mp*/) {
+void CompassModule::handlePairReject(const meshtastic_MeshPacket &mp) {
+    if (_isFromSelf(mp)) return;
     _state.onPairRejected();
     notifyUIChanged();
 }

--- a/firmware-overlay/src/modules/CompassModule/CompassState.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassState.cpp
@@ -212,6 +212,12 @@ void CompassState::deleteTreasure(uint8_t i) {
     saveTreasuresFile();
 }
 
+// --- Status -----------------------------------------------------------
+
+void CompassState::startStatus() {
+    setState(State::STATUS);
+}
+
 // --- Calibration ------------------------------------------------------
 
 void CompassState::startCalibration() {

--- a/firmware-overlay/src/modules/CompassModule/CompassState.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassState.h
@@ -21,6 +21,7 @@ enum class State : uint8_t {
     TRACKING_TREASURE,     // Navigating to a saved waypoint
     SESSION_PAUSED,        // No Desire updates for 5min; backgrounded
     CALIBRATING,           // Magnetometer calibration loop
+    STATUS,                // Read-only status screen (any input dismisses)
 };
 
 struct DiscoveredNode {
@@ -98,6 +99,9 @@ public:
     uint8_t         treasureCount() const { return _treasureCount; }
     const Treasure &treasure(uint8_t i) const { return _treasures[i]; }
     void            deleteTreasure(uint8_t i);
+
+    // Status screen (read-only; transitions to IDLE on any input)
+    void     startStatus();
 
     // Calibration
     void     startCalibration();

--- a/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
+++ b/firmware-overlay/src/modules/CompassModule/CompassUI.cpp
@@ -48,6 +48,7 @@ bool CompassUI::wantUIFrame() const {
         case State::SESSION_PAUSED:
         case State::TRACKING_TREASURE:
         case State::CALIBRATING:
+        case State::STATUS:
             return true;
         default:
             return false;
@@ -68,6 +69,7 @@ void CompassUI::drawFrame(OLEDDisplay *display, OLEDDisplayUiState * /*state*/, 
         case State::SESSION_PAUSED:     drawSessionPaused(display, x, y);      break;
         case State::TRACKING_TREASURE:  drawTrackingTreasure(display, x, y);   break;
         case State::CALIBRATING:        drawCalibrating(display, x, y);        break;
+        case State::STATUS:             drawStatus(display, x, y);             break;
         default:                                                               break;
     }
 }
@@ -204,6 +206,28 @@ void CompassUI::drawSessionPaused(OLEDDisplay *display, int16_t x, int16_t y) {
     display->drawString(x + 4, y + 50, buf);
 }
 
+void CompassUI::drawStatus(OLEDDisplay *display, int16_t x, int16_t y) {
+    auto *st = _owner->state();
+    auto *mg = _owner->mag();
+    const auto &sess = st->session();
+
+    display->setTextAlignment(TEXT_ALIGN_LEFT);
+    display->drawString(x + 4, y + 0,  "Captain's Compass");
+    display->drawString(x + 4, y + 16, mg->isReady() ? "mag: OK" : "mag: not found");
+
+    char buf[40];
+    if (sess.peerNodeNum != 0) {
+        snprintf(buf, sizeof(buf), "session: %s", sess.peerName[0] ? sess.peerName : "(peer)");
+    } else {
+        snprintf(buf, sizeof(buf), "session: (none)");
+    }
+    display->drawString(x + 4, y + 32, buf);
+    snprintf(buf, sizeof(buf), "treasures: %u", static_cast<unsigned>(st->treasureCount()));
+    display->drawString(x + 4, y + 48, buf);
+    display->drawString(x + 4, y + 64, "port: 300");
+    display->drawString(x + 4, y + 96, "(any input dismisses)");
+}
+
 // --- Arrow ------------------------------------------------------------
 
 void CompassUI::drawArrow(OLEDDisplay *display, int16_t cx, int16_t cy, float headingErrorDeg, bool dim) {
@@ -298,6 +322,16 @@ int CompassUI::handleInputEvent(const InputEvent *e) {
                 // End session and refresh frame list so screen rotation
                 // returns to its normal behavior. The "minimize but keep
                 // tracking" UX is a v2 follow-up (bead -dyg).
+                st->endSession();
+                _owner->notifyUIChanged();
+                return 1;
+            }
+            return 0;
+        }
+        case State::STATUS: {
+            // Any input dismisses the read-only status screen back to home.
+            // endSession() with no active session is just a setState(IDLE).
+            if (e->inputEvent != 0) {
                 st->endSession();
                 _owner->notifyUIChanged();
                 return 1;

--- a/firmware-overlay/src/modules/CompassModule/CompassUI.h
+++ b/firmware-overlay/src/modules/CompassModule/CompassUI.h
@@ -40,6 +40,7 @@ private:
     void drawAwaitingPairAccept(OLEDDisplay *display, int16_t x, int16_t y);
     void drawCalibrating(OLEDDisplay *display, int16_t x, int16_t y);
     void drawSessionPaused(OLEDDisplay *display, int16_t x, int16_t y);
+    void drawStatus(OLEDDisplay *display, int16_t x, int16_t y);
 
     // Arrow rendering: center is the (x,y) origin passed in;
     // headingErrorDeg is signed (positive = clockwise).

--- a/patches/apply.py
+++ b/patches/apply.py
@@ -159,16 +159,56 @@ def patch_modules_cpp(dry_run=False):
     print(f"  Patched {path}")
 
 
-def patch_screen_cpp(dry_run=False):
-    """Add 'Compass' entry to the home banner menu in MenuHandler.cpp.
+def patch_menuhandler_h(dry_run=False):
+    """Extend graphics::menuHandler::screenMenus with three Compass values.
 
-    Three coordinated substitutions in src/graphics/draw/MenuHandler.cpp:
+    Why: upstream's banner-menu re-entrance contract forbids calling
+    `screen->showOverlayBanner(...)` from inside another banner's callback
+    (NotificationRenderer assumes the previous banner is closing). Every
+    upstream nested-menu transition uses `menuQueue = X` and lets the next
+    frame's `handleMenuSwitch` dispatch. We follow the same pattern; that
+    requires three queue values:
+
+      * compass_menu             — open the Compass root submenu
+      * compass_treasure_picker  — open the nested treasure-list submenu
+      * compass_toast            — show a deferred toast
+                                   (CompassMenu::pendingToast holds the text)
+
+    Anchor: the last entry of the enum (`DisplayUnits` followed by a
+    closing brace). Stable: the enum is only appended-to upstream and
+    `DisplayUnits` is the current tail at v2.7.15.567b8ea.
+    """
+    _apply(
+        "src/graphics/draw/MenuHandler.h",
+        anchor="        DisplayUnits\n    };",
+        replacement=(
+            "        DisplayUnits,\n"
+            f"        /* {MARKER} */\n"
+            "        compass_menu,\n"
+            "        compass_treasure_picker,\n"
+            "        compass_toast\n"
+            "    };"
+        ),
+        dry_run=dry_run,
+        position="replace",
+    )
+
+
+def patch_screen_cpp(dry_run=False):
+    """Wire the home banner-menu's `Compass` entry to push the Compass submenu.
+
+    Six coordinated substitutions in src/graphics/draw/MenuHandler.cpp:
       1. enum optionsNumbers — add Compass before enumEnd
       2. options array — append Compass entry after the Position branch
       3. bannerCallback lambda — add 'else if (selected == Compass)' case
-    Plus an #include for CompassModule.h.
+         that QUEUES the Compass root submenu (does NOT directly call any
+         CompassModule send method — that was Bug 1 in issue #9).
+      4. handleMenuSwitch — three new cases dispatching the queued values
+         to CompassMenu::buildRoot / buildTreasures / showPendingToast.
+      5. #include "modules/CompassModule/CompassModule.h"
+      6. #include "modules/CompassModule/CompassMenu.h"
 
-    All four are idempotency-checked via the MARKER scan at function entry;
+    All six are idempotency-checked via the MARKER scan at function entry;
     once patched, every subsequent call is a no-op.
     """
     path = "src/graphics/draw/MenuHandler.cpp"
@@ -181,9 +221,12 @@ def patch_screen_cpp(dry_run=False):
     cb_anchor     = ("        } else if (selected == Freetext) {\n"
                      "            cannedMessageModule->LaunchFreetextWithDestination(NODENUM_BROADCAST);\n"
                      "        }")
+    switch_anchor = ("    case throttle_message:\n"
+                     "        screen->showSimpleBanner(\"Too Many Attempts\\nTry again in 60 seconds.\", 5000);\n"
+                     "        break;")
     include_anchor = '#include "MenuHandler.h"'
 
-    for a in (enum_anchor, array_anchor, cb_anchor, include_anchor):
+    for a in (enum_anchor, array_anchor, cb_anchor, switch_anchor, include_anchor):
         if a not in text:
             sys.exit(f"ERROR: anchor missing in {path}: {a!r}")
     if dry_run:
@@ -195,9 +238,6 @@ def patch_screen_cpp(dry_run=False):
         f"Sleep, Compass, enumEnd  /* {MARKER} */",
     )
     text = text.replace(enum_anchor, enum_replacement, 1)
-    # The Position case in v2.7.15 dispatches via injectInputEvent rather than
-    # service->trySendPosition. We don't depend on that detail; we just add a
-    # new Compass case to the lambda after the Freetext case.
 
     # 2. options array: append after Position branch
     array_replacement = (
@@ -208,21 +248,41 @@ def patch_screen_cpp(dry_run=False):
     )
     text = text.replace(array_anchor, array_replacement, 1)
 
-    # 3. bannerCallback lambda: add Compass case after Freetext
+    # 3. bannerCallback lambda: add Compass case after Freetext.
+    # Sets menuQueue and returns; the next frame's handleMenuSwitch builds
+    # the submenu via CompassMenu::buildRoot(). Direct-call to
+    # showOverlayBanner from a callback would race the NotificationRenderer
+    # cleanup of the home banner — see TDD §3.5.
     cb_replacement = (
         cb_anchor + " "
         f"/* {MARKER} */ else if (selected == Compass) {{\n"
-        "            if (CompassModule::instance) {\n"
-        "                CompassModule::instance->sendCapabilityQuery();\n"
-        "            }\n"
+        "            menuQueue = compass_menu;\n"
         "        }"
     )
     text = text.replace(cb_anchor, cb_replacement, 1)
 
-    # 4. include
+    # 4. handleMenuSwitch cases: dispatch the three queue values.
+    switch_replacement = (
+        switch_anchor + "\n"
+        f"    /* {MARKER} */\n"
+        "    case compass_menu:\n"
+        "        compass::CompassMenu::buildRoot();\n"
+        "        break;\n"
+        "    case compass_treasure_picker:\n"
+        "        compass::CompassMenu::buildTreasures();\n"
+        "        break;\n"
+        "    case compass_toast:\n"
+        "        compass::CompassMenu::showPendingToast();\n"
+        "        break;"
+    )
+    text = text.replace(switch_anchor, switch_replacement, 1)
+
+    # 5/6. includes (CompassModule.h for instance ptr, CompassMenu.h for the
+    # static dispatch entry points).
     include_replacement = (
         include_anchor + f'\n// {MARKER}\n'
-        '#include "modules/CompassModule/CompassModule.h"'
+        '#include "modules/CompassModule/CompassModule.h"\n'
+        '#include "modules/CompassModule/CompassMenu.h"'
     )
     text = text.replace(include_anchor, include_replacement, 1)
 
@@ -239,6 +299,7 @@ PATCHES = [
     patch_variant_cpp,
     patch_portnums_proto,
     patch_modules_cpp,
+    patch_menuhandler_h,
     patch_screen_cpp,
 ]
 


### PR DESCRIPTION
Closes #9.

## What's in here

Three nested defects from issue #9, addressed across eight stacked PRs into the \`feat/9-compass-submenu\` feature trunk:

| PR | What |
|---|---|
| #10 | CUJ PRD — \`docs/prd-issue-009-compass-submenu.md\` |
| #11 | Technical design — \`docs/tdd-issue-009-compass-submenu.md\` |
| #12 | bd-9-1: \`CompassMenu\` overlay + queue-dispatch wiring |
| #13 | bd-9-2: Find Desire / Calibrate / End Session real actions |
| #14 | bd-9-3, bd-9-4, bd-9-6: Save Treasure / Treasures picker / Settings toast |
| #15 | bd-9-5: Status read-only screen |
| #16 | bd-9-7: \`loopbackOk=true\` + handle* self-guards (Bug 2 root-cause fix) |
| #17 | bd-9-8, bd-9-9: parent-PRD §7 prose reconciliation + manual QA test plan |

## Bug 1 — submenu (visible symptom)

The home banner-menu's \`Compass\` entry was wired directly to \`CompassModule::sendCapabilityQuery()\`. The parent PRD's CUJ-1..CUJ-8 always assumed \`Menu → Compass → <child>\`; the implementation conflated the parent (\`Compass\`) with one specific child (\`Find Desire\`). Now: home menu's \`Compass\` callback sets \`graphics::menuHandler::menuQueue = compass_menu\` and the next frame's \`handleMenuSwitch\` dispatches to \`compass::CompassMenu::buildRoot()\` which pushes an eight-entry banner-menu (PRD §5).

The queue indirection is necessary because \`screen->showOverlayBanner(...)\` cannot be called recursively from inside a callback — \`NotificationRenderer\` assumes the previous banner is closing when its callback fires. Every upstream nested-menu transition (loraMenu, systemBaseMenu, etc.) uses the same pattern.

## Bug 2 — loopback receive-handler

Root cause was in upstream's \`MeshModule.cpp:112-115\`:

\`\`\`cpp
if ((src == RX_SRC_LOCAL) && !(pi.loopbackOk)) {
    wantsPacket = false;
}
\`\`\`

\`MeshModule\` defaults \`loopbackOk = false\`, so RX_SRC_LOCAL deliveries were filtered before \`wantPacket()\` even ran. CompassModule now sets \`loopbackOk = true\` in its constructor, with self-guards (\`mp.from == nodeDB->getNodeNum() → return\`) on every \`handle*\` method to prevent infinite echoes.

## Bug 3 — PortNum doc drift

Parent PRD §7 said \"reserved range 512-1023 for prototyping\". Actual proto puts \`COMPASS_APP\` at 300, in the 256-511 private-app range. PRD prose updated.

## Build evidence

Clean fetch + apply + build from a pristine \`vendor/\` directory:

\`\`\`
Flash: [========= ]  93.9% (used 765116 bytes from 815104 bytes)
UF2 size: 1530368 bytes
heltec-mesh-node-t114 SUCCESS in 18.7s
\`\`\`

\`+0.2 percentage points\` of flash usage vs the pre-issue-#9 baseline; full UF2 delta is +~24KB from the new menu code, status screen, and self-guards.

## Test plan

- [x] \`make setup && make build\` succeeds from a pristine clone (verified after PR #17 merged into trunk).
- [x] \`patches/apply.py --dry-run\` succeeds — all anchors still match the pinned firmware ref \`v2.7.15.567b8ea\`.
- [ ] Hardware QA (Heltec T114): run all eleven tests in [\`docs/qa-issue-009-compass-submenu.md\`](docs/qa-issue-009-compass-submenu.md). Test 8 specifically verifies the Bug 2 fix and the self-guard regression check.
- [ ] Flash one device, confirm no regression in stock Meshtastic functionality (home banner-menu's \`Backlight\`, \`Position\`, \`Preset\`, \`Freetext\` paths still work — none of our patches touched those branches).

## Beads closed

bd-9-1 through bd-9-10 (this trunk PR closes bd-9-10 itself). All visible at \`bd list --status=closed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)